### PR TITLE
Set style for different bar components

### DIFF
--- a/examples/bar.rs
+++ b/examples/bar.rs
@@ -3,7 +3,7 @@ use embedded_graphics::prelude::*;
 use embedded_graphics_simulator::{
     OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window,
 };
-use lvgl::widgets::{Bar, Label};
+use lvgl::widgets::{Bar, BarComponent, Label};
 use lvgl::{self, Align, Animation, Color, DisplayDriver, Event, Object, Style, UI};
 use lvgl_sys;
 use std::sync::{mpsc, Arc, Mutex};
@@ -40,6 +40,19 @@ fn main() -> Result<(), String> {
     bar.set_align(&mut screen, Align::Center, 0, 0);
     bar.set_range(0, 100);
     bar.set_value(0, Animation::OFF);
+
+    // Set the indicator style for the bar object
+    let mut ind_style = Style::new();
+    ind_style.set_body_main_color(Color::from_rgb((100, 245, 0)));
+    ind_style.set_body_grad_color(Color::from_rgb((100, 245, 0)));
+    bar.set_bar_style(BarComponent::Indicator, ind_style);
+
+    // Set the background style for the bar object
+    let mut bg_style = Style::new();
+    bg_style.set_body_grad_color(Color::from_rgb((255, 255, 255)));
+    bg_style.set_body_main_color(Color::from_rgb((255, 255, 255)));
+    bg_style.set_body_radius(0);
+    bar.set_bar_style(BarComponent::Background, bg_style);
 
     let mut loading_lbl = Label::new(&mut screen);
     loading_lbl.set_text("Loading...");

--- a/lvgl/src/widgets/bar.rs
+++ b/lvgl/src/widgets/bar.rs
@@ -1,6 +1,6 @@
-use crate::support::Animation;
-use crate::support::{NativeObject, ObjectX};
+use crate::support::{Animation, NativeObject, ObjectX, Style};
 use crate::Object;
+use alloc::boxed::Box;
 use core::ptr;
 use lvgl_sys;
 
@@ -30,6 +30,36 @@ impl Bar {
     pub fn set_value(&mut self, value: i16, anim: Animation) {
         unsafe {
             lvgl_sys::lv_bar_set_value(self.core.raw().as_mut(), value, anim.into());
+        }
+    }
+
+    /// Set the style, for the given `BarComponent`
+    pub fn set_bar_style(&mut self, component: BarComponent, style: Style) {
+        let boxed = Box::new(style.raw);
+        unsafe {
+            lvgl_sys::lv_bar_set_style(
+                self.core.raw().as_mut(),
+                component.into(),
+                Box::into_raw(boxed),
+            );
+        }
+    }
+}
+
+/// The different components, of a bar object.
+pub enum BarComponent {
+    /// The background of the bar.
+    Background,
+    /// The indicator of the bar.
+    /// This is what moves/changes, depending on the bar's value.
+    Indicator,
+}
+
+impl From<BarComponent> for lvgl_sys::lv_bar_style_t {
+    fn from(component: BarComponent) -> Self {
+        match component {
+            BarComponent::Background => lvgl_sys::LV_BAR_STYLE_BG as u8,
+            BarComponent::Indicator => lvgl_sys::LV_BAR_STYLE_INDIC as u8,
         }
     }
 }


### PR DESCRIPTION
Possible to set styles, for the various bar components (background and indicator), as outlined in the [lvgl documentation](https://docs.lvgl.io/en/html/object-types/bar.html#_CPPv4Ut7_anon_41).