### PR TITLE
Update README: Added a hint to install SDL2 before running the demos on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ $ DEP_LV_CONFIG_PATH=`pwd` cargo build -Zfeatures=build_dep
 
 ## Running the demo
 
+**Hint for macOS users**: Before you run the demos you need to make sure you have [libsdl](https://www.libsdl.org) installed on your machine. To install it, use HomeBrew:
+
+```shell
+$ brew install sdl2
+```
+
 [This project contains examples that can run in a desktop simulator.](./examples)
 
 First, make sure to pull `lvgl-rs` submodules:


### PR DESCRIPTION
At least in my case it was necessary to install libsdl (SDL2) before I was able to compile the demos on my Mac. I added a hint to the README in order to help other developers that stumble upon that problem.

Fixes #35