### PR TITLE
Add --features="alloc" to run demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ $ git submodule update
 Then run the `demo` example:
 
 ```shell
-$ DEP_LV_CONFIG_PATH=`pwd`/examples/include cargo run --example demo
+$ DEP_LV_CONFIG_PATH=`pwd`/examples/include cargo run --example demo --features="alloc"
 ```
 
 ## Feature Support


### PR DESCRIPTION
Without that, I got the following error from cargo:
```
error: target `demo` in package `lvgl` requires the features: `alloc`
Consider enabling them by passing, e.g., `--features="alloc"`
```