### PR TITLE
Add support for switching screens

### DIFF
--- a/lvgl/src/ui.rs
+++ b/lvgl/src/ui.rs
@@ -110,6 +110,13 @@ where
         }
     }
 
+    pub fn load_scr(&mut self, screen: &mut Obj) -> LvResult<()> {
+        unsafe {
+            lvgl_sys::lv_disp_load_scr(screen.raw()?.as_mut());
+        }
+        Ok(())
+    }
+
     pub fn event_send<W>(&mut self, obj: &mut W, event: Event<W::SpecialEvent>) -> LvResult<()>
     where
         W: Widget,


### PR DESCRIPTION
This PR adds support for changing the current screen via the `load_scr` function based on the `lv_disp_load_scr` from lvgl.

Example usage:
```rust
// Default screen
let mut def_screen = ui.scr_act()?;
// Extra screen
let mut screen = Obj::default();
// ... Add style and widgets to each screen

// Load the extra screen
ui.load_scr(&mut screen);

// Change back to def_screen
ui.load_scr(&mut def_screen);
```