### PR TITLE
Run tests single threaded

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,4 +30,4 @@ jobs:
         run: cargo build --verbose
 
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --verbose -- --test-threads 1


### PR DESCRIPTION
Make all tests run single threaded. We need that because some things we check in the tests cannot support concurrency.