### PR TITLE
Bump license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Rafael Carício
+Copyright (c) 2023 Rafael Carício
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Bump license copyright year to 2023. It irked me so now I'll fix it :)