### PR TITLE
Basic `cross` infrastructure and fixups

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[build.env]
+passthrough = ["DEP_LV_CONFIG_PATH", "LVGL_INCLUDE", "LVGL_LINK"]

--- a/lvgl-sys/build.rs
+++ b/lvgl-sys/build.rs
@@ -1,9 +1,10 @@
 use cc::Build;
 use std::{
-    collections::HashSet,
     env,
     path::{Path, PathBuf},
 };
+#[cfg(feature = "drivers")]
+use std::collections::HashSet;
 
 static CONFIG_NAME: &str = "DEP_LV_CONFIG_PATH";
 
@@ -28,10 +29,12 @@ fn main() {
     let vendor = project_dir.join("vendor");
     let lvgl_src = vendor.join("lvgl").join("src");
 
+    // Some basic defaults; SDL2 is the only driver enabled in the provided
+    // driver config by default
     #[cfg(feature = "drivers")]
     let incl_extra = env::var("LVGL_INCLUDE").unwrap_or("".to_string());
     #[cfg(feature = "drivers")]
-    let link_extra = env::var("LVGL_LINK").unwrap_or("".to_string());
+    let link_extra = env::var("LVGL_LINK").unwrap_or("SDL2".to_string());
 
     #[cfg(feature = "drivers")]
     let drivers = vendor.join("lv_drivers");


### PR DESCRIPTION
When building via `cross` as in #53 certain environment variables need to be forwarded. Also, SDL2 will now be linked in by default if the `LVGL_LINK` variable is unset as it's enabled by default in the `lv_drv_conf.h` that we vendor.