### PR TITLE
Fix `demo` example in release mode

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), LvError> {
 
     // LVGL will render the graphics here first, and seed the rendered image to the
     // display. The buffer size can be set freely.
-    let buffer = DrawBuffer::<{ (HOR_RES * VER_RES / 10) as usize }>::new();
+    let buffer = DrawBuffer::<{ (HOR_RES * VER_RES) as usize }>::new();
     //
     // const NUMBER_OF_DISPLAYS: usize = 1;
     // static DISPLAY_REGISTRY: DisplayRegistry<NUMBER_OF_DISPLAYS> = DisplayRegistry::empty();

--- a/examples/sdl.rs
+++ b/examples/sdl.rs
@@ -23,7 +23,7 @@ fn main() -> LvResult<()> {
     let buffer = DrawBuffer::<{ (HOR_RES * VER_RES) as usize }>::new();
     let display = lv_drv_disp_sdl!(buffer, HOR_RES, VER_RES)?;
     let mut input = lv_drv_input_pointer_sdl!();
-    lvgl::indev_drv_register(&mut input);
+    lvgl::indev_drv_register(&mut input)?;
 
     // Create screen and widgets
     let mut screen = display.get_scr_act()?;
@@ -54,13 +54,11 @@ fn main() -> LvResult<()> {
         }
     })?;
 
-    'running: loop {
+    loop {
         let start = Instant::now();
         lvgl::task_handler();
         //println!("Loop");
         sleep(Duration::from_millis(15));
         lvgl::tick_inc(Instant::now().duration_since(start));
     }
-
-    Ok(())
 }


### PR DESCRIPTION
This is needed for the `demo` example to run when compiled with `--release`.

_**This is terrifying.**_ We're introducing UB somewhere with the buffer logic and it's causing a miscompilation. The buffer logic also segfaults on latest nightly. I figured this out while messing with logic to get custom font support... I'll open a PR for that later once I have this figured out. In the meantime, this is mergeable as-is to at least make latest rustc stable work.