### PR TITLE
Eliminate UB around move semantics in display logic

### DIFF
--- a/lvgl/src/display.rs
+++ b/lvgl/src/display.rs
@@ -194,7 +194,7 @@ impl<'a, const N: usize> DisplayDriver<N> {
                 .ok_or(DisplayError::FailedToRegister)?,
         ) as *mut _;
 
-        disp_drv.user_data = Box::into_raw(Box::new(display_update_callback)) as *mut _;
+        disp_drv.user_data = Box::new(display_update_callback).into_raw() as *mut _;
 
         // Sets trampoline pointer to the function implementation that uses the `F` type for a
         // refresh buffer of size N specifically.
@@ -350,7 +350,8 @@ unsafe extern "C" fn disp_flush_trampoline<'a, F, const N: usize>(
         };
         callback(&update);
     }
-
+    // Not doing this causes a segfault in rust >= 1.69.0
+    *disp_drv = display_driver;
     // Indicate to LVGL that we are ready with the flushing
     lvgl_sys::lv_disp_flush_ready(disp_drv);
 }


### PR DESCRIPTION
The dereferencing of `disp_drv` in [display.rs:330](https://github.com/rafaelcaricio/lvgl-rs/blob/2e2fb1c294ebc7376b92bf4cedb63d1d59ebcba2/lvgl/src/display.rs#L330) would lead to a move and set everything behind the old pointer to null. Simply moving back before the pointer is reused fixes this.

This took at least 4 hours for me to figure out. I hate pointers.