### PR TITLE
Auto-initialize LVGL

### DIFF
--- a/examples/app.rs
+++ b/examples/app.rs
@@ -21,9 +21,6 @@ fn main() {
 
     let shared_native_display = RefCell::new(embedded_graphics_display);
 
-    // LVGL usage
-    lvgl::init();
-
     let buffer = DrawBuffer::<{ (HOR_RES * VER_RES) as usize }>::new();
 
     let display = Display::register(buffer, HOR_RES, VER_RES, |refresh| {

--- a/examples/arc.rs
+++ b/examples/arc.rs
@@ -34,7 +34,6 @@ fn main() -> Result<(), LvError> {
     const HOR_RES: u32 = 240;
     const VER_RES: u32 = 240;
 
-    lvgl::init();
     println!("meminfo init: {:?}", mem_info());
     let mut sim_display: SimulatorDisplay<Rgb565> =
         SimulatorDisplay::new(Size::new(HOR_RES, VER_RES));

--- a/examples/bar.rs
+++ b/examples/bar.rs
@@ -17,7 +17,6 @@ fn main() -> Result<(), LvError> {
     const HOR_RES: u32 = 240;
     const VER_RES: u32 = 240;
 
-    lvgl::init();
     let sim_display: SimulatorDisplay<Rgb565> = SimulatorDisplay::new(Size::new(HOR_RES, VER_RES));
 
     let output_settings = OutputSettingsBuilder::new().scale(2).build();

--- a/examples/button_click.rs
+++ b/examples/button_click.rs
@@ -22,7 +22,6 @@ fn main() -> Result<(), LvError> {
     const HOR_RES: u32 = 240;
     const VER_RES: u32 = 240;
 
-    lvgl::init();
     let mut sim_display: SimulatorDisplay<Rgb565> =
         SimulatorDisplay::new(Size::new(HOR_RES, VER_RES));
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -18,7 +18,6 @@ fn main() -> Result<(), LvError> {
     const HOR_RES: u32 = 240;
     const VER_RES: u32 = 240;
 
-    lvgl::init();
     let mut sim_display: SimulatorDisplay<Rgb565> =
         SimulatorDisplay::new(Size::new(HOR_RES, VER_RES));
     let output_settings = OutputSettingsBuilder::new().scale(1).build();

--- a/examples/meter.rs
+++ b/examples/meter.rs
@@ -18,7 +18,6 @@ fn main() -> Result<(), LvError> {
     const HOR_RES: u32 = 240;
     const VER_RES: u32 = 240;
 
-    lvgl::init();
     let mut sim_display: SimulatorDisplay<Rgb565> =
         SimulatorDisplay::new(Size::new(HOR_RES, VER_RES));
 

--- a/examples/sdl.rs
+++ b/examples/sdl.rs
@@ -19,7 +19,6 @@ fn main() -> LvResult<()> {
     const HOR_RES: u32 = 240;
     const VER_RES: u32 = 240;
 
-    lvgl::init();
     let buffer = DrawBuffer::<{ (HOR_RES * VER_RES) as usize }>::new();
     let display = lv_drv_disp_sdl!(buffer, HOR_RES, VER_RES)?;
     let _input = lv_drv_input_pointer_sdl!(display)?;

--- a/lvgl/Cargo.toml
+++ b/lvgl/Cargo.toml
@@ -18,15 +18,49 @@ embedded-graphics = { version = "0.7.1", optional = true }
 cstr_core = { version = "0.2.6", default-features = false, features = ["alloc"] }
 bitflags = "1.3.2"
 paste = "1.0.11"
+ctor = "0.2.0"
 
 [features]
 default = ["embedded_graphics", "drivers"]
+
+# Enable the embedded_graphics crate as a backend for graphics and input
+# devices. This is the 'legacy' method (supported in LVGL 0.5.2 and below) and
+# requires some manual configuration. See the examples directory for usage
+# examples, and see the documentation on Display and on input devices.
 embedded_graphics = ["embedded-graphics"]
-alloc = ["cstr_core/alloc"]
-lvgl_alloc = ["alloc"]
-use-vendored-config = ["lvgl-sys/use-vendored-config"]
+
+# Enable interop with the lv_drivers project as a graphics and input backend.
+# See the documentation on the drivers module, and the sdl example for a
+# practical example.
 drivers = ["lvgl-sys/drivers"]
+
+# Enable using the alloc crate internally on platforms that support it. Check
+# if your platform supports this crate before enabling.
+alloc = ["cstr_core/alloc"]
+
+# Sets the LVGL allocator as Rust's global allocator. This places ALL memory in
+# LVGL-handled space, and may require growing the memory pool in lv_conf.h
+# above the default.
+lvgl_alloc = ["alloc"]
+
+# Ignores the DEP_LV_CONFIG_PATH environment variable and instead selects the
+# LVGL config that comes bundled with the lvgl-sys crate. Useful if you don't
+# need any extra features, but the default config is quite conservative.
+use-vendored-config = ["lvgl-sys/use-vendored-config"]
+
+# Enables some unstable features. Currently, only #[cfg_accessible] is used.
+# This feature will currently allow:
+# - Using built-in LVGL fonts other than the default
 nightly = []
+
+# Disables auto-initializing LVGL.
+# !!! WARNING !!!
+# Enabling this feature and forgetting to call lvgl::init() before doing
+# anything at all with LVGL *will* cause undefined behaviour and probably a
+# segault. Only enable this if you're really, seriously, absolutely certain
+# that you need it. Unless you're doing something particularly exotic, this is
+# *not* needed, nor would it make anything measurably faster.
+unsafe_no_ctor = []
 
 [build-dependencies]
 quote = "1.0.23"
@@ -71,3 +105,8 @@ required-features = ["alloc", "embedded_graphics"]
 name = "sdl"
 path = "../examples/sdl.rs"
 required-features = ["alloc", "drivers"]
+
+[[example]]
+name = "memtest"
+path = "../examples/memtest.rs"
+required-features = ["lvgl_alloc"]

--- a/lvgl/src/display.rs
+++ b/lvgl/src/display.rs
@@ -194,7 +194,7 @@ impl<'a, const N: usize> DisplayDriver<N> {
                 .ok_or(DisplayError::FailedToRegister)?,
         ) as *mut _;
 
-        disp_drv.user_data = Box::new(display_update_callback).into_raw() as *mut _;
+        disp_drv.user_data = Box::<F>::into_raw(Box::new(display_update_callback)) as *mut _;
 
         // Sets trampoline pointer to the function implementation that uses the `F` type for a
         // refresh buffer of size N specifically.

--- a/lvgl/src/drivers/mod.rs
+++ b/lvgl/src/drivers/mod.rs
@@ -37,7 +37,6 @@
 //!     const HOR_RES: u32 = 240;
 //!     const VER_RES: u32 = 240;
 //!
-//!     lvgl::init();
 //!     let buffer = DrawBuffer::<{ (HOR_RES * VER_RES / 2) as usize }>::new();
 //!     let display = lv_drv_disp_sdl!(buffer, HOR_RES, VER_RES).unwrap();
 //!     // ...
@@ -58,7 +57,6 @@
 //! use lvgl::lv_drv_input_pointer_sdl;
 //!
 //! fn main() {
-//!     lvgl::init();
 //!     // IMPORTANT: Initialize a display driver first!
 //!     // ...
 //!     let _input = lv_drv_input_pointer_sdl!(display);

--- a/lvgl/src/font/generic.rs
+++ b/lvgl/src/font/generic.rs
@@ -5,9 +5,9 @@ pub struct Font {
     inner: Box<lvgl_sys::lv_font_t>,
 }
 
-impl From<Font> for *const lvgl_sys::_lv_font_t {
+impl From<Font> for *const lvgl_sys::lv_font_t {
     fn from(value: Font) -> Self {
-        value.inner.into_raw()
+        Box::<lvgl_sys::lv_font_t>::into_raw(value.inner)
     }
 }
 

--- a/lvgl/src/font/mod.rs
+++ b/lvgl/src/font/mod.rs
@@ -12,7 +12,6 @@
 //! use lvgl::style::Style;
 //!
 //! fn main() {
-//!     lvgl::init();
 //!     let mut my_style = Style::default();
 //!     my_style.set_text_font(Font::montserrat_48());
 //!     // Use the style
@@ -36,7 +35,6 @@
 //! use lvgl::style::Style;
 //!
 //! fn main() {
-//!     lvgl::init();
 //!     let noto_80 = unsafe {
 //!         Font::new_raw(lvgl_sys::noto_sans_numeric_80)
 //!     };

--- a/lvgl/src/input_device/mod.rs
+++ b/lvgl/src/input_device/mod.rs
@@ -18,7 +18,6 @@
 //! use embedded_graphics::prelude::*;
 //! 
 //! fn main() {
-//!     lvgl::init();
 //!     // IMPORTANT: Initialize a display driver first!
 //!     // ...
 //!     // Define the initial state of your input

--- a/lvgl/src/lib.rs
+++ b/lvgl/src/lib.rs
@@ -28,7 +28,6 @@ extern crate alloc;
 // That is because we use `Box` to send memory references to LVGL. Since the global allocator, when
 // `lvgl_alloc` feature is enabled, is the LVGL memory manager then everything is in LVGL
 // managed memory anyways. In that case we can use the Rust's provided Box definition.
-//
 #[cfg(feature = "lvgl_alloc")]
 use ::alloc::boxed::Box;
 
@@ -41,7 +40,6 @@ pub(crate) mod mem;
 // When LVGL allocator is not used on the Rust code, we need a way to add objects to the LVGL
 // managed memory. We implement a very simple `Box` that has the minimal features to copy memory
 // safely to the LVGL managed memory.
-//
 #[cfg(not(feature = "lvgl_alloc"))]
 use crate::mem::Box;
 
@@ -76,14 +74,27 @@ impl RunOnce {
     }
 }
 
+#[cfg(feature = "unsafe_no_ctor")]
 static LVGL_INITIALIZED: RunOnce = RunOnce::new();
 
 /// Initializes LVGL. Call at the start of the program.
+#[cfg(feature = "unsafe_no_ctor")]
 pub fn init() {
     if LVGL_INITIALIZED.swap_and_check() {
         unsafe {
             lvgl_sys::lv_init();
         }
+    }
+}
+
+#[cfg(not(feature = "unsafe_no_ctor"))]
+use ctor::ctor;
+
+#[cfg(not(feature = "unsafe_no_ctor"))]
+#[ctor]
+fn init() {
+    unsafe {
+        lvgl_sys::lv_init();
     }
 }
 

--- a/lvgl/src/lv_core/style.rs
+++ b/lvgl/src/lv_core/style.rs
@@ -7,8 +7,6 @@
 //! use lvgl::style::Style;
 //! 
 //! fn main() {
-//!     lvgl::init();
-//! 
 //!     let mut my_style = Style::default();
 //!     my_style.set_text_color(Color::from_rgb((0, 0, 0)));
 //! 


### PR DESCRIPTION
As discussed in #69, the current API can cause UB if not used properly. The option of using `static_init` to auto-initialize was agreed on, though I opted for [`ctor`](https://crates.io/crates/ctor) since it does the same thing but seems better-maintained. I added a feature also to gate disabling this behaviour, along with a huge disclaimer as to why it shouldn't be used.

Closes #69 