### PR TITLE
Allow LVGL timer to be set from Rust

### DIFF
--- a/examples/include/lv_conf.h
+++ b/examples/include/lv_conf.h
@@ -87,8 +87,8 @@
  *It removes the need to manually update the tick with `lv_tick_inc()`)*/
 #define LV_TICK_CUSTOM 0
 #if LV_TICK_CUSTOM
-    #define LV_TICK_CUSTOM_INCLUDE "Arduino.h"         /*Header for the system time function*/
-    #define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())    /*Expression evaluating to current system time in ms*/
+    #define LV_TICK_CUSTOM_INCLUDE <rs_timer.h>             /*Header for the system time function*/
+    #define LV_TICK_CUSTOM_SYS_TIME_EXPR (rs_lv_timer())    /*Expression evaluating to current system time in ms*/
     /*If using lvgl as ESP32 component*/
     // #define LV_TICK_CUSTOM_INCLUDE "esp_timer.h"
     // #define LV_TICK_CUSTOM_SYS_TIME_EXPR ((esp_timer_get_time() / 1000LL))

--- a/examples/rust_timer.rs
+++ b/examples/rust_timer.rs
@@ -21,7 +21,9 @@ struct Clock {
 
 impl Default for Clock {
     fn default() -> Self {
-        Self { start: Instant::now() }
+        Self {
+            start: Instant::now(),
+        }
     }
 }
 

--- a/examples/rust_timer.rs
+++ b/examples/rust_timer.rs
@@ -1,0 +1,107 @@
+use cstr_core::CString;
+use embedded_graphics::pixelcolor::Rgb565;
+use embedded_graphics::prelude::*;
+use embedded_graphics_simulator::{
+    OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window,
+};
+use lvgl;
+use lvgl::style::Style;
+use lvgl::widgets::{Bar, Label};
+use lvgl::{Align, Animation, Color, Display, DrawBuffer, Event, LvError, Part, Widget};
+use std::cell::RefCell;
+use std::thread::sleep;
+use std::time::Duration;
+use std::time::Instant;
+
+// Example clock, here just reusing standard library features
+use lvgl::timer::LvClock;
+struct Clock {
+    start: Instant,
+}
+
+impl Default for Clock {
+    fn default() -> Self {
+        Self { start: Instant::now() }
+    }
+}
+
+impl LvClock for Clock {
+    fn since_init(&self) -> Duration {
+        Instant::now().duration_since(self.start)
+    }
+}
+
+fn main() -> Result<(), LvError> {
+    const HOR_RES: u32 = 240;
+    const VER_RES: u32 = 240;
+
+    let sim_display: SimulatorDisplay<Rgb565> = SimulatorDisplay::new(Size::new(HOR_RES, VER_RES));
+
+    let output_settings = OutputSettingsBuilder::new().scale(2).build();
+    let mut window = Window::new("Bar Example", &output_settings);
+
+    let shared_native_display = RefCell::new(sim_display);
+
+    let buffer = DrawBuffer::<{ (HOR_RES * VER_RES) as usize }>::new();
+
+    let display = Display::register(buffer, HOR_RES, VER_RES, |refresh| {
+        shared_native_display
+            .borrow_mut()
+            .draw_iter(refresh.as_pixels())
+            .unwrap();
+    })?;
+
+    let mut screen = display.get_scr_act()?;
+
+    let mut screen_style = Style::default();
+    screen_style.set_bg_color(Color::from_rgb((255, 255, 255)));
+    screen_style.set_radius(0);
+    screen.add_style(Part::Main, &mut screen_style)?;
+
+    // Create the bar object
+    let mut bar = Bar::create(&mut screen)?;
+    bar.set_size(175, 20)?;
+    bar.set_align(Align::Center, 0, 10)?;
+    bar.set_range(0, 100)?;
+    bar.on_event(|_b, _e| {
+        println!("Completed!");
+    })?;
+
+    // Set the indicator style for the bar object
+    let mut ind_style = Style::default();
+    ind_style.set_bg_color(Color::from_rgb((100, 245, 100)));
+    bar.add_style(Part::Any, &mut ind_style)?;
+
+    let mut loading_lbl = Label::create(&mut screen)?;
+    loading_lbl.set_text(CString::new("Loading...").unwrap().as_c_str())?;
+    loading_lbl.set_align(Align::OutTopMid, 0, 0)?;
+
+    let mut loading_style = Style::default();
+    loading_style.set_text_color(Color::from_rgb((0, 0, 0)));
+    loading_lbl.add_style(Part::Main, &mut loading_style)?;
+
+    let mut i = 0;
+    let clock = Clock::default();
+    'running: loop {
+        if i > 100 {
+            i = 0;
+            lvgl::event_send(&mut bar, Event::Clicked)?;
+        }
+        bar.set_value(i, Animation::ON)?;
+        i += 1;
+
+        lvgl::task_handler();
+        window.update(&shared_native_display.borrow());
+
+        for event in window.events() {
+            match event {
+                SimulatorEvent::Quit => break 'running,
+                _ => {}
+            }
+        }
+        sleep(Duration::from_millis(15));
+        lvgl::timer::update_clock(&clock).unwrap();
+    }
+
+    Ok(())
+}

--- a/lvgl-sys/Cargo.toml
+++ b/lvgl-sys/Cargo.toml
@@ -26,3 +26,4 @@ bindgen = "0.64.0"
 [features]
 use-vendored-config = []
 drivers = []
+rust_timer = []

--- a/lvgl-sys/build.rs
+++ b/lvgl-sys/build.rs
@@ -45,7 +45,8 @@ fn main() {
     // Some basic defaults; SDL2 is the only driver enabled in the provided
     // driver config by default
     #[cfg(feature = "drivers")]
-    let incl_extra = env::var("LVGL_INCLUDE").unwrap_or("/usr/include,/usr/local/include".to_string());
+    let incl_extra =
+        env::var("LVGL_INCLUDE").unwrap_or("/usr/include,/usr/local/include".to_string());
     #[cfg(feature = "drivers")]
     let link_extra = env::var("LVGL_LINK").unwrap_or("SDL2".to_string());
 
@@ -169,7 +170,9 @@ fn main() {
 
     let mut additional_args = Vec::new();
     if target.ends_with("emscripten") {
-        if let Ok(em_path) = env::var("EMSDK") {
+        match env::var("EMSDK") {
+            Ok(em_path) =>
+        {
             additional_args.push("-I".to_string());
             additional_args.push(format!(
                 "{}/upstream/emscripten/system/include/libc",
@@ -185,6 +188,8 @@ fn main() {
                 "{}/upstream/emscripten/system/include/SDL",
                 em_path
             ));
+        }
+        Err(_) => panic!("The EMSDK environment variable is not set. Has emscripten been properly initialized?")
         }
     }
 

--- a/lvgl-sys/build.rs
+++ b/lvgl-sys/build.rs
@@ -28,6 +28,8 @@ fn main() {
     let shims_dir = project_dir.join("shims");
     let vendor = project_dir.join("vendor");
     let lvgl_src = vendor.join("lvgl").join("src");
+    #[cfg(feature = "rust_timer")]
+    let timer_shim = vendor.join("include").join("timer");
 
     let current_dir = canonicalize(PathBuf::from(env::var("PWD").unwrap()));
     let font_extra_src = {
@@ -139,6 +141,8 @@ fn main() {
     if let Some(p) = &font_extra_src {
         cfg.includes(p);
     }
+    #[cfg(feature = "rust_timer")]
+    cfg.include(&timer_shim);
     #[cfg(feature = "drivers")]
     cfg.include(&drivers);
     #[cfg(feature = "drivers")]
@@ -154,9 +158,6 @@ fn main() {
         vendor.to_str().unwrap(),
         "-fvisibility=default",
     ];
-
-    //#[cfg(feature = "drivers")]
-    //incl_extra.split(',').for_each(|a| { cc_args.append(&mut vec!["-l"]); cc_args.append(&mut vec![a]) });
 
     // Set correct target triple for bindgen when cross-compiling
     let target = env::var("TARGET").expect("Cargo build scripts always have TARGET");
@@ -209,6 +210,8 @@ fn main() {
     let bindings = bindings
         .header(shims_dir.join("lvgl_drv.h").to_str().unwrap())
         .parse_callbacks(Box::new(ignored_macros));
+    //#[cfg(feature = "rust_timer")]
+    //let bindings = bindings.header(shims_dir.join("rs_timer.h").to_str().unwrap());
     let bindings = bindings
         .generate_comments(false)
         .derive_default(true)

--- a/lvgl-sys/vendor/include/timer/rs_timer.h
+++ b/lvgl-sys/vendor/include/timer/rs_timer.h
@@ -1,0 +1,14 @@
+#ifndef LVGL_TIMER_API_H
+#define LVGL_TIMER_API_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint32_t rs_lv_timer();
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* LVGL_TIMER_API */

--- a/lvgl/Cargo.toml
+++ b/lvgl/Cargo.toml
@@ -117,5 +117,5 @@ required-features = ["alloc", "drivers"]
 
 [[example]]
 name = "rust_timer"
-path = "../examples/rust_timer.h"
+path = "../examples/rust_timer.rs"
 required-features = ["alloc", "embedded_graphics", "rust_timer"]

--- a/lvgl/Cargo.toml
+++ b/lvgl/Cargo.toml
@@ -48,6 +48,10 @@ lvgl_alloc = ["alloc"]
 # need any extra features, but the default config is quite conservative.
 use-vendored-config = ["lvgl-sys/use-vendored-config"]
 
+# Enables using a custom tick function in Rust for LVGL. See the documentation
+# on the timer module for usage notes.
+rust_timer = ["lvgl-sys/rust_timer"]
+
 # Enables some unstable features. Currently, only #[cfg_accessible] is used.
 # This feature will currently allow:
 # - Using built-in LVGL fonts other than the default
@@ -110,3 +114,8 @@ required-features = ["alloc", "embedded_graphics"]
 name = "sdl"
 path = "../examples/sdl.rs"
 required-features = ["alloc", "drivers"]
+
+[[example]]
+name = "rust_timer"
+path = "../examples/rust_timer.h"
+required-features = ["alloc", "embedded_graphics", "rust_timer"]

--- a/lvgl/src/drivers/lv_drv_input.rs
+++ b/lvgl/src/drivers/lv_drv_input.rs
@@ -6,7 +6,7 @@ macro_rules! lv_drv_input_pointer_evdev {
             $crate::input_device::pointer::Pointer::new_raw(
                 Some(lvgl_sys::evdev_read),
                 None,
-                &$disp
+                &$disp,
             )
         }
     };
@@ -19,7 +19,7 @@ macro_rules! lv_drv_input_pointer_gtk {
             $crate::input_device::pointer::Pointer::new_raw(
                 Some(lvgl_sys::gtkdrv_mouse_read_cb),
                 None,
-                &$disp
+                &$disp,
             )
         }
     };
@@ -32,7 +32,7 @@ macro_rules! lv_drv_input_pointer_sdl {
             $crate::input_device::pointer::Pointer::new_raw(
                 Some(lvgl_sys::sdl_mouse_read),
                 None,
-                &$disp
+                &$disp,
             )
         }
     };
@@ -46,7 +46,7 @@ macro_rules! lv_drv_input_ad_touch {
             $crate::input_device::pointer::Pointer::new_raw(
                 Some(lvgl_sys::ad_touch_read),
                 None,
-                &$disp
+                &$disp,
             )
         }
     };
@@ -60,7 +60,7 @@ macro_rules! lv_drv_input_ft5406ee8 {
             $crate::input_device::pointer::Pointer::new_raw(
                 Some(lvgl_sys::ft5406ee8_read),
                 None,
-                &$disp
+                &$disp,
             )
         }
     };
@@ -71,7 +71,11 @@ macro_rules! lv_drv_input_xpt2046 {
     ($disp:ident) => {
         unsafe {
             lvgl_sys::xpt2046_init();
-            $crate::input_device::pointer::Pointer::new_raw(Some(lvgl_sys::xpt2046_read), None, &$disp)
+            $crate::input_device::pointer::Pointer::new_raw(
+                Some(lvgl_sys::xpt2046_read),
+                None,
+                &$disp,
+            )
         }
     };
 }

--- a/lvgl/src/drivers/mod.rs
+++ b/lvgl/src/drivers/mod.rs
@@ -6,14 +6,14 @@
 //!
 //! The `sdl` example shows how to use both input and display drivers to port
 //! the `button_click` example.
-//! 
+//!
 //! # Building
 //! To compile in support for drivers, ensure the `drivers` feature is enabled
 //! (this feature is enabled by default). Also ensure that the C configuration
 //! for the drivers is located at the same path as the configuration for LVGL
 //! itsel (i.e. the directory pointed to by `DEP_LV_CONFIG_PATH` contains both
 //! `lv_conf.h` and `lv_drv_conf.h`).
-//! 
+//!
 //! Depending on desired drivers, certain environment variables need to be set.
 //! `LVGL_INCLUDE` lists directories to be searched for headers during
 //! compilation, and `LVGL_LINK` lists libraries that will be linked in. By
@@ -32,7 +32,7 @@
 //! ```no_run
 //! use lvgl::DrawBuffer;
 //! use lvgl::lv_drv_disp_sdl;
-//! 
+//!
 //! fn main() {
 //!     const HOR_RES: u32 = 240;
 //!     const VER_RES: u32 = 240;

--- a/lvgl/src/functions.rs
+++ b/lvgl/src/functions.rs
@@ -2,6 +2,7 @@ use crate::display::{Display, DisplayDriver};
 use crate::input_device::InputDriver;
 use crate::{Event, LvError, LvResult, Obj, Widget};
 use core::ptr::NonNull;
+#[cfg(not(feature = "rust_timer"))]
 use core::time::Duration;
 use core::{ptr, result};
 
@@ -49,6 +50,7 @@ pub(crate) fn get_str_act(disp: Option<&Display>) -> Result<Obj> {
 /// Runs an LVGL tick lasting a given `core::time::Duration`. This function
 /// should be called periodically.
 #[inline]
+#[cfg(not(feature = "rust_timer"))]
 pub fn tick_inc(tick_period: Duration) {
     unsafe {
         lvgl_sys::lv_tick_inc(tick_period.as_millis() as u32);

--- a/lvgl/src/input_device/generic.rs
+++ b/lvgl/src/input_device/generic.rs
@@ -46,7 +46,7 @@ pub trait InputDriver<D> {
             unsafe extern "C" fn(*mut lvgl_sys::_lv_indev_drv_t, *mut lvgl_sys::lv_indev_data_t),
         >,
         feedback_cb: Option<unsafe extern "C" fn(*mut lvgl_sys::_lv_indev_drv_t, u8)>,
-        display: &crate::Display
+        display: &crate::Display,
     ) -> LvResult<D>;
 
     unsafe fn set_descriptor(&mut self, descriptor: *mut lvgl_sys::lv_indev_t) -> LvResult<()>;

--- a/lvgl/src/input_device/mod.rs
+++ b/lvgl/src/input_device/mod.rs
@@ -1,12 +1,12 @@
 //! Input driver logic and handling
-//! 
+//!
 //! LVGL supports 4 types of input device. The current status as to support in
 //! this library is:
 //! - Pointer: Fully supported
 //! - Keyboard: Unsupported
 //! - Button: Unsupported
 //! - Encoder: Unsupported
-//! 
+//!
 //! The general order of operations when creating an input device is
 //! initializing an instance of the desired device, setting a callback function
 //! (and any other parameters and functions, depending on type), and
@@ -16,7 +16,7 @@
 //! use lvgl::input_device::InputDriver;
 //! use lvgl::input_device::pointer::{Pointer, PointerInputData};
 //! use embedded_graphics::prelude::*;
-//! 
+//!
 //! fn main() {
 //!     // IMPORTANT: Initialize a display driver first!
 //!     // ...

--- a/lvgl/src/input_device/pointer.rs
+++ b/lvgl/src/input_device/pointer.rs
@@ -50,7 +50,7 @@ impl InputDriver<Pointer> for Pointer {
 
         match crate::indev_drv_register(&mut dev) {
             Ok(()) => Ok(dev),
-            Err(e) => Err(e)
+            Err(e) => Err(e),
         }
     }
 
@@ -63,7 +63,7 @@ impl InputDriver<Pointer> for Pointer {
             unsafe extern "C" fn(*mut lvgl_sys::_lv_indev_drv_t, *mut lvgl_sys::lv_indev_data_t),
         >,
         feedback_cb: Option<unsafe extern "C" fn(*mut lvgl_sys::_lv_indev_drv_t, u8)>,
-        _: &crate::Display
+        _: &crate::Display,
     ) -> LvResult<Self> {
         let driver = unsafe {
             let mut indev_drv = MaybeUninit::uninit();
@@ -74,7 +74,7 @@ impl InputDriver<Pointer> for Pointer {
             indev_drv.feedback_cb = feedback_cb;
             indev_drv
         };
-        
+
         let mut dev = Self {
             driver,
             descriptor: None,

--- a/lvgl/src/lib.rs
+++ b/lvgl/src/lib.rs
@@ -60,6 +60,9 @@ pub mod font;
 pub mod input_device;
 pub mod widgets;
 
+#[cfg(feature = "rust_timer")]
+pub mod timer;
+
 struct RunOnce(AtomicBool);
 
 impl RunOnce {

--- a/lvgl/src/lv_core/style.rs
+++ b/lvgl/src/lv_core/style.rs
@@ -1,15 +1,15 @@
 //! Styling for LVGL objects and widgets
-//! 
+//!
 //! Objects in LVGL can have associated styling information. After a `Style` is
 //! created and configured, it can be added to any object or widget:
 //! ```
 //! use lvgl::{Color, Widget};
 //! use lvgl::style::Style;
-//! 
+//!
 //! fn main() {
 //!     let mut my_style = Style::default();
 //!     my_style.set_text_color(Color::from_rgb((0, 0, 0)));
-//! 
+//!
 //!     //my_widget.add_style(Part::Main, &mut my_style).unwrap();
 //!     // ...
 //! }

--- a/lvgl/src/timer.rs
+++ b/lvgl/src/timer.rs
@@ -1,0 +1,76 @@
+//! Rust timer handling logic
+//! 
+//! LVGL allows for an external timer function to be used. This feature enables
+//! a generic `LvClock` interface that can be used to build Rust-native timers.
+//! 
+//! # Building
+//!
+//! Set `LV_TICK_CUSTOM` to `1` and `LV_TICK_CUSTOM_INCLUDE` to `<rs_timer.h>`
+//! in `lv_conf.h`, and enable the `rust_timer` feature on the `lvgl` crate to
+//! enable this functionality.
+//! 
+//! # Usage
+//! 
+//! Implement the `lvgl::timer::LvClock` trait on a type and initialize it on
+//! the first frame. The `since_init()` function should return a `Duration`
+//! representing time elapsed since the beginning of the first frame of the
+//! program.
+//! 
+//! ```no_run
+//! use lvgl::timer::LvClock;
+//! 
+//! struct Clock {
+//!     start: Instant,
+//! }
+//! 
+//! impl Default for Clock {
+//!     fn default() -> Self {
+//!         Self {
+//!             start: Instant::now(),
+//!         }
+//!     }
+//! }
+//! 
+//! impl LvClock for Clock {
+//!     fn since_init(&self) -> Duration {
+//!         Instant::now().duration_since(self.start)
+//!     }
+//! }
+//! 
+//! fn main() {
+//!     // Initialize displays, etc.
+//!     let clock = Clock::default();
+//!     loop {
+//!         // Looping UI logic
+//!         lvgl::timer::update_clock(&clock).unwrap();
+//!     }
+//! }
+//! ```
+//! 
+//! For a full example implementation similar to the above, see the
+//! `rust_timer` example. When running, make sure to modify the config in
+//! `examples/include/lv_conf.h` (or your own) as above first.
+
+use core::time::Duration;
+use core::num::TryFromIntError;
+
+static mut RET_VAL: u32 = 0;
+
+/// An LVGL-compatible clock
+pub trait LvClock {
+    /// Returns the time since the clock was first initialized
+    fn since_init(&self) -> Duration;
+}
+
+/// Synchronize the clock with LVGL. FIXME: When to call
+pub fn update_clock(clock: &impl LvClock) -> Result<(), TryFromIntError> {
+    unsafe {
+        RET_VAL = clock.since_init().as_millis().try_into()?
+    }
+    Ok(())
+}
+
+#[no_mangle]
+unsafe extern "C" fn rs_lv_timer() -> u32 {
+    RET_VAL
+}

--- a/lvgl/src/timer.rs
+++ b/lvgl/src/timer.rs
@@ -1,28 +1,28 @@
 //! Rust timer handling logic
-//! 
+//!
 //! LVGL allows for an external timer function to be used. This feature enables
 //! a generic `LvClock` interface that can be used to build Rust-native timers.
-//! 
+//!
 //! # Building
 //!
 //! Set `LV_TICK_CUSTOM` to `1` and `LV_TICK_CUSTOM_INCLUDE` to `<rs_timer.h>`
 //! in `lv_conf.h`, and enable the `rust_timer` feature on the `lvgl` crate to
 //! enable this functionality.
-//! 
+//!
 //! # Usage
-//! 
+//!
 //! Implement the `lvgl::timer::LvClock` trait on a type and initialize it on
 //! the first frame. The `since_init()` function should return a `Duration`
 //! representing time elapsed since the beginning of the first frame of the
 //! program.
-//! 
+//!
 //! ```no_run
 //! use lvgl::timer::LvClock;
-//! 
+//!
 //! struct Clock {
 //!     start: Instant,
 //! }
-//! 
+//!
 //! impl Default for Clock {
 //!     fn default() -> Self {
 //!         Self {
@@ -30,13 +30,13 @@
 //!         }
 //!     }
 //! }
-//! 
+//!
 //! impl LvClock for Clock {
 //!     fn since_init(&self) -> Duration {
 //!         Instant::now().duration_since(self.start)
 //!     }
 //! }
-//! 
+//!
 //! fn main() {
 //!     // Initialize displays, etc.
 //!     let clock = Clock::default();
@@ -46,13 +46,13 @@
 //!     }
 //! }
 //! ```
-//! 
+//!
 //! For a full example implementation similar to the above, see the
 //! `rust_timer` example. When running, make sure to modify the config in
 //! `examples/include/lv_conf.h` (or your own) as above first.
 
-use core::time::Duration;
 use core::num::TryFromIntError;
+use core::time::Duration;
 
 static mut RET_VAL: u32 = 0;
 
@@ -64,9 +64,7 @@ pub trait LvClock {
 
 /// Synchronize the clock with LVGL. FIXME: When to call
 pub fn update_clock(clock: &impl LvClock) -> Result<(), TryFromIntError> {
-    unsafe {
-        RET_VAL = clock.since_init().as_millis().try_into()?
-    }
+    unsafe { RET_VAL = clock.since_init().as_millis().try_into()? }
     Ok(())
 }
 


### PR DESCRIPTION
Implements a new trait, `LvClock`, which can be implemented to define a clock. I adapted the `bar` example so far but I'll make it its own example (+ write docs), and also I need to fix a bunch of compiler warnings. But, it's already functional :D

Closes #25 