### PR TITLE
More documentation and dead code disabling

### DIFF
--- a/lvgl/src/lv_core/obj.rs
+++ b/lvgl/src/lv_core/obj.rs
@@ -1,3 +1,10 @@
+//! Native LVGL objects
+//! 
+//! Objects are individual elements of a displayed surface, similar to widgets.
+//! Specifically, an object can either be a widget or a screen. Screen objects
+//! are special in that they do not have a parent object and do not implement
+//! the `Widget` trait, but do implement `NativeObject`.
+
 use crate::lv_core::style::Style;
 use crate::{Align, LvError, LvResult};
 use core::ptr;

--- a/lvgl/src/widgets/mod.rs
+++ b/lvgl/src/widgets/mod.rs
@@ -1,4 +1,11 @@
-mod arc;
+//! Widget-specific features
+//! 
+//! Widgets represent individual elements on the screen. Each widget has
+//! associated information, namely its parent widget and its styling data. A
+//! widget with no parent will have a screen as its parent. Style data is
+//! inherited from parent objects by default.
+
+//mod arc;
 mod bar;
 mod label;
 mod meter;


### PR DESCRIPTION
Add more docs and comment out the inclusion of the `arc.rs` module.

Since #67 no special functionality is implemented on the `Arc` widget anymore, so it will no longer be compiled in. I'm keeping it in the source since we might want to implement new functionality in the future.