### PR TITLE
Fix segfault on certain buffer sizes

### DIFF
--- a/lvgl/src/display.rs
+++ b/lvgl/src/display.rs
@@ -178,6 +178,7 @@ impl<const N: usize> DrawBuffer<N> {
     }
 }
 
+#[repr(C)]
 pub(crate) struct DisplayDriver<const N: usize> {
     pub(crate) disp_drv: lvgl_sys::lv_disp_drv_t,
     _buffer: DrawBuffer<N>,


### PR DESCRIPTION
This was a lovely (awful) issue to fix, and was actually the core issue underpinning #74. When implementing the `lv_disp_t`, the LVGL docs specify that the driver object *must* be the [first member of the struct](https://docs.lvgl.io/latest/en/html/porting/display.html#_CPPv49lv_disp_t). In #67 I changed the struct we have here to also hold the buffer, as this simplified both the API and the internal logic. However, I was *not* aware of the requirement re: struct layout, and Rust [doesn't actually guarantee any specific type layout](https://doc.rust-lang.org/reference/type-layout.html#the-default-representation); so, on certain buffer sizes, the compiler was putting the buffer before the driver.

On the bright side, all this segfault chasing has quadrupled my productivity with `lldb`.