### PR TITLE
crates.io fixup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1]
+
+### Fixed
+- Excluded LVGL demos due to crates.io binary size limits
+
 ## [0.6.0]
 
 ### Added
@@ -86,7 +91,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - No (direct) dependency on `clang-rs`
 
-[Unreleased]: https://github.com/rafaelcaricio/lvgl-rs/compare/0.6.0..HEAD
+[Unreleased]: https://github.com/rafaelcaricio/lvgl-rs/compare/0.6.1..HEAD
+[0.6.1]: https://github.com/rafaelcaricio/lvgl-rs/compare/0.6.0..0.6.1
 [0.6.0]: https://github.com/rafaelcaricio/lvgl-rs/compare/0.5.2..0.6.0
 [0.5.2]: https://github.com/rafaelcaricio/lvgl-rs/compare/0.4.0..0.5.2
 [0.4.0]: https://github.com/rafaelcaricio/lvgl-rs/compare/0.3.1..0.4.0

--- a/lvgl-codegen/Cargo.toml
+++ b/lvgl-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lvgl-codegen"
-version = "0.6.0"
+version = "0.6.1"
 description = "Code generation based on LVGL source code"
 authors = ["Rafael Caricio <crates.lvgl@caric.io>"]
 readme = "README.md"

--- a/lvgl-sys/Cargo.toml
+++ b/lvgl-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lvgl-sys"
 description = "Raw bindings to the LVGL C library."
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Rafael Caricio <crates.lvgl-sys@caric.io>"]
 edition = "2021"
 license = "MIT"
@@ -12,6 +12,13 @@ categories = ["external-ffi-bindings", "embedded", "gui", "no-std"]
 keywords = ["littlevgl", "lvgl"]
 build = "build.rs"
 links = "lvgl"
+exclude = [
+    "vendor/lvgl/demos",
+    "vendor/lvgl/tests",
+    "vendor/lvgl/examples",
+    "vendor/lvgl/docs",
+    "vendor/lvgl/scripts"
+]
 
 [lib]
 name = "lvgl_sys"

--- a/lvgl/Cargo.toml
+++ b/lvgl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lvgl"
 description = "LVGL bindings for Rust. A powerful and easy-to-use embedded GUI with many widgets, advanced visual effects (opacity, antialiasing, animations) and low memory requirements (16K RAM, 64K Flash)."
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Rafael Caricio <crates.lvgl@caric.io>"]
 edition = "2021"
 repository = "https://github.com/rafaelcaricio/lvgl-rs"
@@ -12,7 +12,7 @@ keywords = ["littlevgl", "lvgl", "graphical_interfaces"]
 build = "build.rs"
 
 [dependencies]
-lvgl-sys = { version = "0.6.0", path = "../lvgl-sys" }
+lvgl-sys = { version = "0.6.1", path = "../lvgl-sys" }
 cty = "0.2.2"
 embedded-graphics = { version = "0.7.1", optional = true }
 cstr_core = { version = "0.2.6", default-features = false, features = ["alloc"] }
@@ -74,8 +74,8 @@ unsafe_no_autoinit = []
 [build-dependencies]
 quote = "1.0.23"
 proc-macro2 = "1.0.51"
-lvgl-codegen = { version = "0.6.0", path = "../lvgl-codegen" }
-lvgl-sys = { version = "0.6.0", path = "../lvgl-sys" }
+lvgl-codegen = { version = "0.6.1", path = "../lvgl-codegen" }
+lvgl-sys = { version = "0.6.1", path = "../lvgl-sys" }
 
 [dev-dependencies]
 embedded-graphics-simulator = "0.4.0"


### PR DESCRIPTION
Need to exclude things from the `lvgl-sys` for `crates.io` to be happy. Requires a version bump...