### PR TITLE
Implement more functions

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -52,7 +52,7 @@ fn main() -> Result<(), LvError> {
     button.set_align(Align::LeftMid, 30, 0);
     button.set_size(180, 80);
     let mut btn_lbl = Label::create(&mut button)?;
-    btn_lbl.set_text(CString::new("Click me!").unwrap().as_c_str())?;
+    btn_lbl.set_text(CString::new("Click me!").unwrap().as_c_str());
 
     let mut btn_state = false;
 
@@ -66,10 +66,10 @@ fn main() -> Result<(), LvError> {
         if let lvgl::Event::Clicked = event {
             if btn_state {
                 let nt = CString::new("Click me!").unwrap();
-                btn_lbl.set_text(nt.as_c_str()).unwrap();
+                btn_lbl.set_text(nt.as_c_str());
             } else {
                 let nt = CString::new("Clicked!").unwrap();
-                btn_lbl.set_text(nt.as_c_str()).unwrap();
+                btn_lbl.set_text(nt.as_c_str());
             }
             btn_state = !btn_state;
         }

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -12,8 +12,8 @@ use lvgl::input_device::{
 };
 use lvgl::misc::anim::{AnimRepeatCount, Animation};
 use lvgl::style::Style;
-use lvgl::widgets::{Btn, Label};
-use lvgl::{Align, Color, Display, DrawBuffer, LvError, Part, Widget};
+use lvgl::widgets::{Btn, Label, Widget};
+use lvgl::{Align, Color, Display, DrawBuffer, LvError, Part};
 use std::thread::sleep;
 use std::time::Duration;
 use std::time::Instant;
@@ -46,10 +46,10 @@ fn main() -> Result<(), LvError> {
 
     let mut screen_style = Style::default();
     screen_style.set_bg_color(Color::from_rgb((0, 0, 0)));
-    screen.add_style(Part::Main, &mut screen_style);
+    screen.add_style(screen_style.into_raw(), Part::Main.into());
     // Create the button
     let mut button = Btn::create(&mut screen)?;
-    button.set_align(Align::LeftMid, 30, 0);
+    button.align(Align::LeftMid.into(), 30, 0);
     button.set_size(180, 80);
     let mut btn_lbl = Label::create(&mut button)?;
     btn_lbl.set_text(CString::new("Click me!").unwrap().as_c_str());
@@ -57,7 +57,7 @@ fn main() -> Result<(), LvError> {
     let mut btn_state = false;
 
     let mut anim = Animation::new(&mut button, Duration::from_secs(1), 0, 60, |obj, val| {
-        obj.set_align(Align::LeftMid, val, 0)
+        obj.align(Align::LeftMid.into(), val as i16, 0)
     })?;
     anim.set_repeat_count(AnimRepeatCount::Infinite);
     anim.start();

--- a/examples/arc.rs
+++ b/examples/arc.rs
@@ -62,7 +62,7 @@ fn main() -> Result<(), LvError> {
     arc.set_end_angle(135);
 
     let mut loading_lbl = Label::create(&mut screen)?;
-    loading_lbl.set_text(CString::new("Loading...").unwrap().as_c_str())?;
+    loading_lbl.set_text(CString::new("Loading...").unwrap().as_c_str());
     loading_lbl.set_align(Align::OutTopMid, 0, 0);
     //loading_lbl.set_label_align(LabelAlign::Center)?;
 
@@ -82,7 +82,7 @@ fn main() -> Result<(), LvError> {
             println!("mem info running: {:?}", mem_info());
         }
         angle = if forward { angle + 1 } else { angle - 1 };
-        arc.set_end_angle(angle + 135)?;
+        arc.set_end_angle(angle + 135);
         i += 1;
 
         lvgl::task_handler();

--- a/examples/arc.rs
+++ b/examples/arc.rs
@@ -6,8 +6,8 @@ use embedded_graphics_simulator::{
 };
 use lvgl;
 use lvgl::style::Style;
-use lvgl::widgets::{Arc, Label};
-use lvgl::{Align, Color, Display, DrawBuffer, LvError, Part, Widget};
+use lvgl::widgets::{Arc, Label, Widget};
+use lvgl::{Align, Color, Display, DrawBuffer, LvError, Part};
 use lvgl_sys;
 use std::thread::sleep;
 use std::time::Duration;
@@ -52,23 +52,23 @@ fn main() -> Result<(), LvError> {
     let mut screen_style = Style::default();
     screen_style.set_bg_color(Color::from_rgb((255, 255, 255)));
     screen_style.set_radius(0);
-    screen.add_style(Part::Main, &mut screen_style);
+    screen.add_style(screen_style.into_raw(), Part::Main.into());
 
     // Create the arc object
     let mut arc = Arc::create(&mut screen)?;
     arc.set_size(150, 150);
-    arc.set_align(Align::Center, 0, 10);
+    arc.align(Align::Center.into(), 0, 10);
     arc.set_start_angle(135);
     arc.set_end_angle(135);
 
     let mut loading_lbl = Label::create(&mut screen)?;
     loading_lbl.set_text(CString::new("Loading...").unwrap().as_c_str());
-    loading_lbl.set_align(Align::OutTopMid, 0, 0);
+    loading_lbl.align(Align::OutTopMid.into(), 0, 0);
     //loading_lbl.set_label_align(LabelAlign::Center)?;
 
     let mut loading_style = Style::default();
     loading_style.set_text_color(Color::from_rgb((0, 0, 0)));
-    loading_lbl.add_style(Part::Main, &mut loading_style);
+    loading_lbl.add_style(loading_style.into_raw(), Part::Main.into());
 
     let mut angle = 0;
     let mut forward = true;

--- a/examples/bar.rs
+++ b/examples/bar.rs
@@ -6,8 +6,8 @@ use embedded_graphics_simulator::{
 };
 use lvgl;
 use lvgl::style::Style;
-use lvgl::widgets::{Bar, Label};
-use lvgl::{Align, AnimationState, Color, Display, DrawBuffer, Event, LvError, Part, Widget};
+use lvgl::widgets::{Bar, Label, Widget};
+use lvgl::{Align, AnimationState, Color, Display, DrawBuffer, Event, LvError, Part};
 use std::thread::sleep;
 use std::time::Duration;
 use std::time::Instant;
@@ -33,12 +33,12 @@ fn main() -> Result<(), LvError> {
     let mut screen_style = Style::default();
     screen_style.set_bg_color(Color::from_rgb((255, 255, 255)));
     screen_style.set_radius(0);
-    screen.add_style(Part::Main, &mut screen_style);
+    screen.add_style(screen_style.into_raw(), Part::Main.into());
 
     // Create the bar object
     let mut bar = Bar::create(&mut screen)?;
     bar.set_size(175, 20);
-    bar.set_align(Align::Center, 0, 10);
+    bar.align(Align::Center.into(), 0, 10);
     bar.set_range(0, 100);
     bar.on_event(|_b, _e| {
         println!("Completed!");
@@ -47,15 +47,15 @@ fn main() -> Result<(), LvError> {
     // Set the indicator style for the bar object
     let mut ind_style = Style::default();
     ind_style.set_bg_color(Color::from_rgb((100, 245, 100)));
-    bar.add_style(Part::Any, &mut ind_style);
+    bar.add_style(ind_style.into_raw(), Part::Any.into());
 
     let mut loading_lbl = Label::create(&mut screen)?;
     loading_lbl.set_text(CString::new("Loading...").unwrap().as_c_str());
-    loading_lbl.set_align(Align::OutTopMid, 0, 0);
+    loading_lbl.align(Align::OutTopMid.into(), 0, 0);
 
     let mut loading_style = Style::default();
     loading_style.set_text_color(Color::from_rgb((0, 0, 0)));
-    loading_lbl.add_style(Part::Main, &mut loading_style);
+    loading_lbl.add_style(loading_style.into_raw(), Part::Main.into());
 
     let mut i = 0;
     'running: loop {

--- a/examples/bar.rs
+++ b/examples/bar.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), LvError> {
     let mut bar = Bar::create(&mut screen)?;
     bar.set_size(175, 20);
     bar.set_align(Align::Center, 0, 10);
-    bar.set_range(0, 100)?;
+    bar.set_range(0, 100);
     bar.on_event(|_b, _e| {
         println!("Completed!");
     })?;
@@ -50,7 +50,7 @@ fn main() -> Result<(), LvError> {
     bar.add_style(Part::Any, &mut ind_style);
 
     let mut loading_lbl = Label::create(&mut screen)?;
-    loading_lbl.set_text(CString::new("Loading...").unwrap().as_c_str())?;
+    loading_lbl.set_text(CString::new("Loading...").unwrap().as_c_str());
     loading_lbl.set_align(Align::OutTopMid, 0, 0);
 
     let mut loading_style = Style::default();

--- a/examples/bar.rs
+++ b/examples/bar.rs
@@ -67,7 +67,7 @@ fn main() -> Result<(), LvError> {
             // - implementation of `Widget` is not general enough
             // lvgl::event_send(&mut bar, Event::Clicked);
         }
-        bar.set_value(i, AnimationState::ON);
+        bar.set_value(i, AnimationState::ON.into());
         i += 1;
 
         lvgl::task_handler();

--- a/examples/button_click.rs
+++ b/examples/button_click.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), LvError> {
     button.set_align(Align::LeftMid, 30, 0);
     button.set_size(180, 80);
     let mut btn_lbl = Label::create(&mut button)?;
-    btn_lbl.set_text(CString::new("Click me!").unwrap().as_c_str())?;
+    btn_lbl.set_text(CString::new("Click me!").unwrap().as_c_str());
 
     let mut btn_state = false;
     button.on_event(|_btn, event| {
@@ -59,10 +59,10 @@ fn main() -> Result<(), LvError> {
         if let lvgl::Event::Clicked = event {
             if btn_state {
                 let nt = CString::new("Click me!").unwrap();
-                btn_lbl.set_text(nt.as_c_str()).unwrap();
+                btn_lbl.set_text(nt.as_c_str());
             } else {
                 let nt = CString::new("Clicked!").unwrap();
-                btn_lbl.set_text(nt.as_c_str()).unwrap();
+                btn_lbl.set_text(nt.as_c_str());
             }
             btn_state = !btn_state;
         }

--- a/examples/button_click.rs
+++ b/examples/button_click.rs
@@ -11,8 +11,8 @@ use lvgl::input_device::{
     InputDriver,
 };
 use lvgl::style::Style;
-use lvgl::widgets::{Btn, Label};
-use lvgl::{Align, Color, Display, DrawBuffer, LvError, Part, Widget};
+use lvgl::widgets::{Btn, Label, Widget};
+use lvgl::{Align, Color, Display, DrawBuffer, LvError, Part};
 use std::thread::sleep;
 use std::time::Duration;
 use std::time::Instant;
@@ -45,10 +45,10 @@ fn main() -> Result<(), LvError> {
 
     let mut screen_style = Style::default();
     screen_style.set_bg_color(Color::from_rgb((0, 0, 0)));
-    screen.add_style(Part::Main, &mut screen_style);
+    screen.add_style(screen_style.into_raw(), Part::Main.into());
     // Create the button
     let mut button = Btn::create(&mut screen)?;
-    button.set_align(Align::LeftMid, 30, 0);
+    button.align(Align::LeftMid.into(), 30, 0);
     button.set_size(180, 80);
     let mut btn_lbl = Label::create(&mut button)?;
     btn_lbl.set_text(CString::new("Click me!").unwrap().as_c_str());

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -7,8 +7,8 @@ use embedded_graphics_simulator::{
 use lvgl;
 use lvgl::font::Font;
 use lvgl::style::Style;
-use lvgl::widgets::Label;
-use lvgl::{Align, Color, Display, DrawBuffer, LvError, Part, TextAlign, Widget};
+use lvgl::widgets::{Label, Widget};
+use lvgl::{Align, Color, Display, DrawBuffer, LvError, Part, TextAlign};
 use lvgl_sys;
 use std::thread::sleep;
 use std::time::Duration;
@@ -35,14 +35,14 @@ fn main() -> Result<(), LvError> {
 
     // Create screen and widgets
     let binding = display?;
-    let screen = binding.get_scr_act();
+    let mut screen = binding.get_scr_act()?;
 
     println!("Before all widgets: {:?}", mem_info());
 
     let mut screen_style = Style::default();
     screen_style.set_bg_color(Color::from_rgb((0, 0, 0)));
     screen_style.set_radius(0);
-    screen?.add_style(Part::Main, &mut screen_style);
+    screen.add_style(screen_style.into_raw(), Part::Main.into());
 
     let mut time = Label::from("20:46");
     let mut style_time = Style::default();
@@ -52,8 +52,8 @@ fn main() -> Result<(), LvError> {
     // See font module documentation for an explanation of the unsafe block
     style_time.set_text_font(unsafe { Font::new_raw(lvgl_sys::noto_sans_numeric_80) });
 
-    time.add_style(Part::Main, &mut style_time);
-    time.set_align(Align::Center, 0, 90);
+    time.add_style(style_time.into_raw(), Part::Main.into());
+    time.align(Align::Center.into(), 0, 90);
     time.set_width(240);
     time.set_height(240);
 
@@ -61,13 +61,13 @@ fn main() -> Result<(), LvError> {
     bt.set_width(50);
     bt.set_height(80);
     let _ = bt.set_recolor(true);
-    bt.set_align(Align::TopLeft, 0, 0);
+    bt.align(Align::TopLeft.into(), 0, 0);
 
     let mut power: Label = "#fade2a 20%#".into();
     let _ = power.set_recolor(true);
     power.set_width(80);
     power.set_height(20);
-    power.set_align(Align::TopRight, 40, 0);
+    power.align(Align::TopRight.into(), 40, 0);
 
     let mut i = 0;
     'running: loop {

--- a/examples/rust_timer.rs
+++ b/examples/rust_timer.rs
@@ -6,8 +6,8 @@ use embedded_graphics_simulator::{
 };
 use lvgl;
 use lvgl::style::Style;
-use lvgl::widgets::{Bar, Label};
-use lvgl::{Align, AnimationState, Color, Display, DrawBuffer, Event, LvError, Part, Widget};
+use lvgl::widgets::{Bar, Label, Widget};
+use lvgl::{Align, AnimationState, Color, Display, DrawBuffer, Event, LvError, Part};
 use std::thread::sleep;
 use std::time::Duration;
 use std::time::Instant;
@@ -53,12 +53,12 @@ fn main() -> Result<(), LvError> {
     let mut screen_style = Style::default();
     screen_style.set_bg_color(Color::from_rgb((255, 255, 255)));
     screen_style.set_radius(0);
-    screen.add_style(Part::Main, &mut screen_style);
+    screen.add_style(screen_style.into_raw(), Part::Main.into());
 
     // Create the bar object
     let mut bar = Bar::create(&mut screen)?;
     bar.set_size(175, 20);
-    bar.set_align(Align::Center, 0, 10);
+    bar.align(Align::Center.into(), 0, 10);
     bar.set_range(0, 100);
     bar.on_event(|_b, _e| {
         println!("Completed!");
@@ -67,15 +67,15 @@ fn main() -> Result<(), LvError> {
     // Set the indicator style for the bar object
     let mut ind_style = Style::default();
     ind_style.set_bg_color(Color::from_rgb((100, 245, 100)));
-    bar.add_style(Part::Any, &mut ind_style);
+    bar.add_style(ind_style.into_raw(), Part::Main.into());
 
     let mut loading_lbl = Label::create(&mut screen)?;
     loading_lbl.set_text(CString::new("Loading...").unwrap().as_c_str());
-    loading_lbl.set_align(Align::OutTopMid, 0, 0);
+    loading_lbl.align(Align::OutTopMid.into(), 0, 0);
 
     let mut loading_style = Style::default();
     loading_style.set_text_color(Color::from_rgb((0, 0, 0)));
-    loading_lbl.add_style(Part::Main, &mut loading_style);
+    loading_lbl.add_style(loading_style.into_raw(), Part::Main.into());
 
     let mut i = 0;
     let clock = Clock::default();

--- a/examples/rust_timer.rs
+++ b/examples/rust_timer.rs
@@ -53,13 +53,13 @@ fn main() -> Result<(), LvError> {
     let mut screen_style = Style::default();
     screen_style.set_bg_color(Color::from_rgb((255, 255, 255)));
     screen_style.set_radius(0);
-    screen.add_style(Part::Main, &mut screen_style)?;
+    screen.add_style(Part::Main, &mut screen_style);
 
     // Create the bar object
     let mut bar = Bar::create(&mut screen)?;
-    bar.set_size(175, 20)?;
-    bar.set_align(Align::Center, 0, 10)?;
-    bar.set_range(0, 100)?;
+    bar.set_size(175, 20);
+    bar.set_align(Align::Center, 0, 10);
+    bar.set_range(0, 100);
     bar.on_event(|_b, _e| {
         println!("Completed!");
     })?;
@@ -67,24 +67,24 @@ fn main() -> Result<(), LvError> {
     // Set the indicator style for the bar object
     let mut ind_style = Style::default();
     ind_style.set_bg_color(Color::from_rgb((100, 245, 100)));
-    bar.add_style(Part::Any, &mut ind_style)?;
+    bar.add_style(Part::Any, &mut ind_style);
 
     let mut loading_lbl = Label::create(&mut screen)?;
-    loading_lbl.set_text(CString::new("Loading...").unwrap().as_c_str())?;
-    loading_lbl.set_align(Align::OutTopMid, 0, 0)?;
+    loading_lbl.set_text(CString::new("Loading...").unwrap().as_c_str());
+    loading_lbl.set_align(Align::OutTopMid, 0, 0);
 
     let mut loading_style = Style::default();
     loading_style.set_text_color(Color::from_rgb((0, 0, 0)));
-    loading_lbl.add_style(Part::Main, &mut loading_style)?;
+    loading_lbl.add_style(Part::Main, &mut loading_style);
 
     let mut i = 0;
     let clock = Clock::default();
     'running: loop {
         if i > 100 {
             i = 0;
-            lvgl::event_send(&mut bar, Event::Clicked)?;
+            lvgl::event_send(&mut bar, Event::Clicked);
         }
-        bar.set_value(i, AnimationState::ON)?;
+        bar.set_value(i, AnimationState::ON);
         i += 1;
 
         lvgl::task_handler();

--- a/examples/rust_timer.rs
+++ b/examples/rust_timer.rs
@@ -84,7 +84,7 @@ fn main() -> Result<(), LvError> {
             i = 0;
             lvgl::event_send(&mut bar, Event::Clicked);
         }
-        bar.set_value(i, AnimationState::ON);
+        bar.set_value(i, AnimationState::ON.into());
         i += 1;
 
         lvgl::task_handler();

--- a/examples/sdl.rs
+++ b/examples/sdl.rs
@@ -34,7 +34,7 @@ fn main() -> LvResult<()> {
     button.set_align(Align::LeftMid, 30, 0);
     button.set_size(180, 80);
     let mut btn_lbl = Label::create(&mut button)?;
-    btn_lbl.set_text(CString::new("Click me!").unwrap().as_c_str())?;
+    btn_lbl.set_text(CString::new("Click me!").unwrap().as_c_str());
 
     let mut btn_state = false;
     button.on_event(|_btn, event| {
@@ -42,10 +42,10 @@ fn main() -> LvResult<()> {
         if let lvgl::Event::Clicked = event {
             if btn_state {
                 let nt = CString::new("Click me!").unwrap();
-                btn_lbl.set_text(nt.as_c_str()).unwrap();
+                btn_lbl.set_text(nt.as_c_str());
             } else {
                 let nt = CString::new("Clicked!").unwrap();
-                btn_lbl.set_text(nt.as_c_str()).unwrap();
+                btn_lbl.set_text(nt.as_c_str());
             }
             btn_state = !btn_state;
         }

--- a/examples/sdl.rs
+++ b/examples/sdl.rs
@@ -8,9 +8,10 @@ use lvgl::input_device::InputDriver;
 use lvgl::lv_drv_disp_sdl;
 use lvgl::lv_drv_input_pointer_sdl;
 use lvgl::style::Style;
+use lvgl::widgets::Widget;
 use lvgl::widgets::{Btn, Label};
 use lvgl::LvResult;
-use lvgl::{Align, Color, DrawBuffer, Part, Widget};
+use lvgl::{Align, Color, DrawBuffer, Part};
 use std::thread::sleep;
 use std::time::Duration;
 use std::time::Instant;
@@ -28,10 +29,10 @@ fn main() -> LvResult<()> {
 
     let mut screen_style = Style::default();
     screen_style.set_bg_color(Color::from_rgb((0, 0, 0)));
-    screen.add_style(Part::Main, &mut screen_style);
+    screen.add_style(screen_style.into_raw(), Part::Main.into());
     // Create the button
     let mut button = Btn::create(&mut screen)?;
-    button.set_align(Align::LeftMid, 30, 0);
+    button.align(Align::LeftMid.into(), 30, 0);
     button.set_size(180, 80);
     let mut btn_lbl = Label::create(&mut button)?;
     btn_lbl.set_text(CString::new("Click me!").unwrap().as_c_str());

--- a/lvgl-codegen/src/lib.rs
+++ b/lvgl-codegen/src/lib.rs
@@ -259,6 +259,9 @@ impl Rusty for LvFunc {
                     } else if arg.typ.is_mut_native_object() {
                         let var = arg.get_value_usage();
                         quote! {#var.raw().as_mut()}
+                    }else if arg.typ.is_const_native_object() {
+                        let var = arg.get_value_usage();
+                        quote! {#var.raw().as_ref()}
                     } else {
                         let var = arg.get_value_usage();
                         quote!(#var)
@@ -460,8 +463,14 @@ impl LvType {
         self.literal_name == "* mut cty :: c_char"
     }
 
+    pub fn is_const_native_object(&self) -> bool {
+        self.literal_name == "* const lv_obj_t" || 
+        self.literal_name == "* const _lv_obj_t"
+    }
+
     pub fn is_mut_native_object(&self) -> bool {
-        self.literal_name == "* mut lv_obj_t"
+        self.literal_name == "* mut lv_obj_t" || 
+        self.literal_name == "* mut _lv_obj_t"
     }
 
     pub fn is_pointer(&self) -> bool {
@@ -481,6 +490,8 @@ impl Rusty for LvType {
             quote!(&cstr_core::CStr)
         } else if self.is_mut_str() {
             quote!(&mut cstr_core::CString)
+        }else if self.is_const_native_object() {
+            quote!(&impl NativeObject)
         } else if self.is_mut_native_object() {
             quote!(&mut impl NativeObject)
         } else if self.is_array() {

--- a/lvgl-codegen/src/lib.rs
+++ b/lvgl-codegen/src/lib.rs
@@ -402,10 +402,8 @@ impl Rusty for LvType {
     type Parent = LvArg;
 
     fn code(&self, _parent: &Self::Parent) -> WrapperResult<TokenStream> {
-        let val = if self.is_const_str() {
+        let val = if self.is_const_str() || self.is_mut_str() {
             quote!(&cstr_core::CStr)
-        }else if self.is_mut_str() {
-            quote!(&mut cstr_core::CStr)
         } else if self.is_mut_native_object() {
             quote!(&mut impl NativeObject)
         } else{
@@ -691,7 +689,7 @@ mod test {
         let code = btnmatrix_set_map.code(&parent_widget).unwrap();
         let expected_code = quote! {
 
-            pub fn set_map(&mut self, map: &mut cstr_core::CStr) -> () {
+            pub fn set_map(&mut self, map: &cstr_core::CStr) -> () {
                 unsafe {
                     lvgl_sys::lv_btnmatrix_set_map(
                         self.core.raw().as_mut(),

--- a/lvgl-codegen/src/lib.rs
+++ b/lvgl-codegen/src/lib.rs
@@ -342,8 +342,9 @@ impl LvArg {
         if self.get_type().is_mut_str(){
             // Convert CString to *mut i8
             let name = format_ident!("{}",&self.name);
+            let name_raw = format_ident!("{}_raw",&self.name);
             quote! {
-                let raw_c_str = #name.clone().into_raw();
+                let #name_raw = #name.clone().into_raw();
             }
         }else{
             quote! {}
@@ -354,8 +355,9 @@ impl LvArg {
         if self.get_type().is_mut_str(){
             // Convert *mut i8 back to CString
             let name = format_ident!("{}",&self.name);
+            let name_raw = format_ident!("{}_raw",&self.name);
             quote! {
-                *#name = cstr_core::CString::from_raw(raw_c_str);
+                *#name = cstr_core::CString::from_raw(#name_raw);
             }
         }else{
             quote! {}
@@ -369,8 +371,9 @@ impl LvArg {
                 #ident.as_ptr()
             }
         }else if self.typ.is_mut_str() {
+            let ident_raw = format_ident!("{}_raw",&ident);
             quote! {
-                raw_c_str
+                #ident_raw
             }
         } else {
             quote! {
@@ -730,13 +733,13 @@ mod test {
 
             pub fn get_selected_str(&mut self, buf: &mut cstr_core::CString, buf_size:u32) -> () {
                 unsafe {
-                    let raw_c_str = buf.clone().into_raw();
+                    let buf_raw = buf.clone().into_raw();
                     lvgl_sys::lv_dropdown_get_selected_str(
                         self.core.raw().as_mut(),
-                        raw_c_str,
+                        buf_raw,
                         buf_size
                     );
-                    *buf = CString::from_raw(raw_c_str);
+                    *buf = cstr_core::CString::from_raw(buf_raw);
                 }
             }
 

--- a/lvgl-codegen/src/lib.rs
+++ b/lvgl-codegen/src/lib.rs
@@ -217,7 +217,7 @@ impl Rusty for LvFunc {
                 let next_arg = if i == 0 {
                     quote!()
                 } else {
-                    let var = arg.get_postprocessiong();
+                    let var = arg.get_postprocessing();
                     quote!(#var)
                 };
                 if args.is_empty() {
@@ -354,7 +354,7 @@ impl LvArg {
         }
     }
 
-    pub fn get_postprocessiong(&self) -> TokenStream {
+    pub fn get_postprocessing(&self) -> TokenStream {
         if self.get_type().is_mut_str() {
             // Convert *mut i8 back to CString
             let name = format_ident!("{}", &self.name);

--- a/lvgl/build.rs
+++ b/lvgl/build.rs
@@ -20,7 +20,6 @@ fn main() {
         .collect();
 
     let code = quote! {
-        use lvgl_sys::lv_obj_t;
         #(#widgets_impl)*
     };
 

--- a/lvgl/build.rs
+++ b/lvgl/build.rs
@@ -20,6 +20,7 @@ fn main() {
         .collect();
 
     let code = quote! {
+        use lvgl_sys::lv_obj_t;
         #(#widgets_impl)*
     };
 

--- a/lvgl/build.rs
+++ b/lvgl/build.rs
@@ -20,6 +20,7 @@ fn main() {
         .collect();
 
     let code = quote! {
+        use lvgl_sys::*;
         #(#widgets_impl)*
     };
 

--- a/lvgl/src/functions.rs
+++ b/lvgl/src/functions.rs
@@ -69,9 +69,9 @@ pub fn task_handler() {
 
 /// Directly send an event to a specific widget.
 #[inline]
-pub fn event_send<W: for<'a> Widget<'a>>(
+pub fn event_send<'a, W: Widget<'a>>(
     obj: &mut W,
-    event: Event<<W as Widget<'_>>::SpecialEvent>,
+    event: Event<<W as Widget<'a>>::SpecialEvent>,
 ) {
     unsafe {
         lvgl_sys::lv_event_send(obj.raw().as_mut(), event.into(), ptr::null_mut());

--- a/lvgl/src/functions.rs
+++ b/lvgl/src/functions.rs
@@ -1,6 +1,7 @@
 use crate::display::{Display, DisplayDriver};
 use crate::input_device::InputDriver;
-use crate::{Event, LvError, LvResult, Obj, Widget};
+use crate::widgets::Widget;
+use crate::{Event, LvError, LvResult, Obj};
 use core::ptr::NonNull;
 #[cfg(not(feature = "rust_timer"))]
 use core::time::Duration;

--- a/lvgl/src/lv_core/obj.rs
+++ b/lvgl/src/lv_core/obj.rs
@@ -5,8 +5,8 @@
 //! are special in that they do not have a parent object but do still implement
 //! `NativeObject`.
 
-use crate::lv_core::style::Style;
-use crate::{Align, LvError, LvResult};
+use crate::widgets::Widget;
+use crate::{LvError, LvResult};
 use core::fmt::{self, Debug};
 use core::marker::PhantomData;
 use core::ptr::{self, NonNull};
@@ -78,7 +78,7 @@ impl NativeObject for Obj<'_> {
 }
 
 /// A wrapper for all LVGL common operations on generic objects.
-pub trait Widget<'a>: NativeObject + Sized + 'a {
+/*pub trait Widget<'a>: NativeObject + Sized + 'a {
     type SpecialEvent;
     type Part: Into<lvgl_sys::lv_part_t>;
 
@@ -149,7 +149,7 @@ pub trait Widget<'a>: NativeObject + Sized + 'a {
             );
         }
     }
-}
+}*/
 
 impl<'a> Widget<'a> for Obj<'a> {
     type SpecialEvent = u32;
@@ -185,7 +185,7 @@ macro_rules! define_object {
         impl<'a> $item<'a> {
             pub fn on_event<F>(&mut self, f: F) -> $crate::LvResult<()>
             where
-                F: FnMut(Self, $crate::support::Event<<Self as $crate::Widget<'a>>::SpecialEvent>),
+                F: FnMut(Self, $crate::support::Event<<Self as Widget<'a>>::SpecialEvent>),
             {
                 use $crate::NativeObject;
                 unsafe {
@@ -210,7 +210,7 @@ macro_rules! define_object {
             }
         }
 
-        impl<'a> $crate::Widget<'a> for $item<'a> {
+        impl<'a> Widget<'a> for $item<'a> {
             type SpecialEvent = $event_type;
             type Part = $part_type;
 

--- a/lvgl/src/lv_core/screen.rs
+++ b/lvgl/src/lv_core/screen.rs
@@ -1,4 +1,4 @@
-use crate::{LvError, LvResult, NativeObject, Obj, Part, Widget};
+use crate::{widgets::Widget, LvError, LvResult, NativeObject, Obj, Part};
 
 /// An LVGL screen.
 #[derive(Debug)]

--- a/lvgl/src/lv_core/style.rs
+++ b/lvgl/src/lv_core/style.rs
@@ -3,13 +3,13 @@
 //! Objects in LVGL can have associated styling information. After a `Style` is
 //! created and configured, it can be added to any object or widget:
 //! ```
-//! use lvgl::{Color, Widget};
+//! use lvgl::{Color, Part};
 //! use lvgl::style::Style;
 //!
 //! let mut my_style = Style::default();
 //! my_style.set_text_color(Color::from_rgb((0, 0, 0)));
 //!
-//! //my_widget.add_style(Part::Main, &mut my_style).unwrap();
+//! // my_widget.add_style(my_style.into_raw(), Part::Main.into());
 //! // ...
 //! ```
 //! All methods on the `Style` type directly lower to their C LVGL

--- a/lvgl/src/lv_core/style.rs
+++ b/lvgl/src/lv_core/style.rs
@@ -33,6 +33,12 @@ pub struct Style {
     pub(crate) raw: Box<lvgl_sys::lv_style_t>,
 }
 
+impl Style {
+    pub fn into_raw(self) -> &'static mut lvgl_sys::lv_style_t {
+        unsafe { self.raw.into_raw().as_mut().unwrap() }
+    }
+}
+
 impl Debug for Style {
     // TODO: Decode and dump style values
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/lvgl/src/misc/anim.rs
+++ b/lvgl/src/misc/anim.rs
@@ -115,7 +115,7 @@ where
         // yes, we have to do it this way. Casting `obj` directly to `&mut Obj` segfaults
         let obj = (*(obj as *mut T)).raw();
         if !anim.as_ref().user_data.is_null() {
-            let callback = &mut *(obj.as_ref().user_data as *mut F);
+            let callback = &mut *(anim.as_ref().user_data as *mut F);
             let mut obj_nondrop = Obj::from_raw(obj).unwrap();
             callback(&mut obj_nondrop, val);
             mem::forget(obj_nondrop)

--- a/lvgl/src/misc/anim.rs
+++ b/lvgl/src/misc/anim.rs
@@ -1,4 +1,4 @@
-use crate::{Box, LvResult, Obj, Widget};
+use crate::{widgets::Widget, Box, LvResult, Obj};
 use core::{
     mem::{self, MaybeUninit},
     num::TryFromIntError,

--- a/lvgl/src/support.rs
+++ b/lvgl/src/support.rs
@@ -1,5 +1,4 @@
-use crate::display::DisplayError;
-use crate::Widget;
+use crate::{display::DisplayError, widgets::Widget};
 use core::convert::{TryFrom, TryInto};
 #[cfg(feature = "nightly")]
 use core::error::Error;

--- a/lvgl/src/widgets/bar.rs
+++ b/lvgl/src/widgets/bar.rs
@@ -3,20 +3,20 @@ use crate::widgets::Bar;
 use crate::NativeObject;
 
 impl Bar<'_> {
-    /// Set minimum and the maximum values of the bar
-    //pub fn set_range(&mut self, min: i16, max: i16) -> LvResult<()> {
-    //    unsafe {
-    //        lvgl_sys::lv_bar_set_range(self.core.raw()?.as_mut(), min, max);
-    //    }
-    //    Ok(())
-    //}
+    /*/// Set minimum and the maximum values of the bar
+    pub fn set_range(&mut self, min: i16, max: i16) -> LvResult<()> {
+       unsafe {
+           lvgl_sys::lv_bar_set_range(self.core.raw()?.as_mut(), min, max);
+       }
+       Ok(())
+    }*/
 
-    /// Set a new value on the bar
-    pub fn set_value(&mut self, value: i32, anim: AnimationState) {
-        unsafe {
-            lvgl_sys::lv_bar_set_value(self.core.raw().as_mut(), value, anim.into());
-        }
-    }
+    /*/// Set a new value on the bar
+    //pub fn set_value(&mut self, value: i32, anim: AnimationState) {
+    //    unsafe {
+    //        lvgl_sys::lv_bar_set_value(self.core.raw().as_mut(), value, anim.into());
+    //    }
+    //}*/
 }
 /*
 /// The different parts, of a bar object.

--- a/lvgl/src/widgets/keyboard.rs
+++ b/lvgl/src/widgets/keyboard.rs
@@ -1,14 +1,4 @@
 use crate::widgets::{Keyboard, Textarea};
 use crate::NativeObject;
 
-impl Keyboard<'_> {
-    /// Associates a given `Textarea` to the keyboard.
-    pub fn set_textarea(&mut self, textarea: &mut Textarea) {
-        unsafe {
-            lvgl_sys::lv_keyboard_set_textarea(
-                self.raw().as_mut() as *mut lvgl_sys::lv_obj_t,
-                textarea.raw().as_mut() as *mut lvgl_sys::lv_obj_t,
-            )
-        }
-    }
-}
+impl Keyboard<'_> {}

--- a/lvgl/src/widgets/label.rs
+++ b/lvgl/src/widgets/label.rs
@@ -32,11 +32,11 @@ mod alloc_imp {
 }
 
 impl Label<'_> {
-    pub fn set_long_mode(&mut self, long_mode: LabelLongMode) {
+    /*pub fn set_long_mode(&mut self, long_mode: LabelLongMode) {
         unsafe {
             lvgl_sys::lv_label_set_long_mode(self.raw().as_mut(), long_mode.into());
         }
-    }
+    }*/
 
     pub fn get_long_mode(&self) -> u8 {
         unsafe { lvgl_sys::lv_label_get_long_mode(self.raw().as_ref()) }

--- a/lvgl/src/widgets/label.rs
+++ b/lvgl/src/widgets/label.rs
@@ -38,7 +38,7 @@ impl Label<'_> {
         }
     }*/
 
-    pub fn get_long_mode(&self) -> u8 {
+    /*pub fn get_long_mode(&self) -> u8 {
         unsafe { lvgl_sys::lv_label_get_long_mode(self.raw().as_ref()) }
-    }
+    }*/
 }

--- a/lvgl/src/widgets/table.rs
+++ b/lvgl/src/widgets/table.rs
@@ -3,7 +3,7 @@ use crate::widgets::Table;
 use core::mem::MaybeUninit;
 
 impl Table<'_> {
-    /// Returns the selected cell as a tuple of (row, column).
+    /*/// Returns the selected cell as a tuple of (row, column).
     pub fn get_selected_cell(&self) -> (u16, u16) {
         let mut row = MaybeUninit::<u16>::uninit();
         let mut col = MaybeUninit::<u16>::uninit();
@@ -16,5 +16,5 @@ impl Table<'_> {
             // The values get initialised by LVGL
             (row.assume_init(), col.assume_init())
         }
-    }
+    }*/
 }

--- a/lvgl/src/widgets/table.rs
+++ b/lvgl/src/widgets/table.rs
@@ -3,12 +3,6 @@ use crate::widgets::Table;
 use core::mem::MaybeUninit;
 
 impl Table<'_> {
-    /// Sets the column width. Row height cannot be set manually and is
-    /// calculated by LVGL based on styling parameters.
-    pub fn set_col_width(&mut self, column: u16, width: i16) {
-        unsafe { lvgl_sys::lv_table_set_col_width(self.core.raw().as_ptr(), column, width) }
-    }
-
     /// Returns the selected cell as a tuple of (row, column).
     pub fn get_selected_cell(&self) -> (u16, u16) {
         let mut row = MaybeUninit::<u16>::uninit();


### PR DESCRIPTION
This PR reworks the LvArgs and LvFunc implementations to handle mutable/immutable primitives, structs, NativeObjects and strings. Also fixes the examples.

<details>
<summary>List of functions implemented</summary>

```diff
+ lv_animimg_set_duration
- lv_animimg_set_src
+ lv_arc_align_obj_to_angle
+ lv_arc_get_mode
+ lv_arc_rotate_obj_to_angle
+ lv_arc_set_mode
+ lv_arc_set_range
+ lv_arc_set_value
+ lv_bar_get_mode
+ lv_bar_set_mode
+ lv_bar_set_start_value
+ lv_bar_set_value
+ lv_btnmatrix_clear_btn_ctrl
+ lv_btnmatrix_clear_btn_ctrl_all
- lv_btnmatrix_get_btn_text
- lv_btnmatrix_get_map
+ lv_btnmatrix_has_btn_ctrl
+ lv_btnmatrix_set_btn_ctrl
+ lv_btnmatrix_set_btn_ctrl_all
+ lv_btnmatrix_set_ctrl_map
- lv_btnmatrix_set_map
- lv_calendar_get_btnmatrix
- lv_calendar_get_highlighted_dates
+ lv_calendar_get_pressed_date
- lv_calendar_get_showed_date
- lv_calendar_get_today_date
- lv_calendar_set_day_names
+ lv_calendar_set_highlighted_dates
+ lv_calendar_set_showed_date
+ lv_calendar_set_today_date
+ lv_canvas_blur_hor
+ lv_canvas_blur_ver
- lv_canvas_copy_buf
+ lv_canvas_draw_arc
- lv_canvas_draw_img
+ lv_canvas_draw_line
+ lv_canvas_draw_polygon
+ lv_canvas_draw_rect
+ lv_canvas_draw_text
+ lv_canvas_fill_bg
- lv_canvas_get_img
+ lv_canvas_get_px
- lv_canvas_set_buffer
+ lv_canvas_set_palette
+ lv_canvas_set_px_color
+ lv_canvas_set_px_opa
+ lv_canvas_transform
- lv_chart_add_cursor
- lv_chart_add_series
+ lv_chart_get_cursor_point
+ lv_chart_get_point_pos_by_id
- lv_chart_get_series_next
+ lv_chart_get_type
- lv_chart_get_x_array
+ lv_chart_get_x_start_point
- lv_chart_get_y_array
+ lv_chart_hide_series
+ lv_chart_remove_series
+ lv_chart_set_all_value
+ lv_chart_set_axis_tick
+ lv_chart_set_cursor_point
+ lv_chart_set_cursor_pos
+ lv_chart_set_ext_x_array
+ lv_chart_set_ext_y_array
+ lv_chart_set_next_value
+ lv_chart_set_next_value2
+ lv_chart_set_range
+ lv_chart_set_series_color
+ lv_chart_set_type
+ lv_chart_set_update_mode
+ lv_chart_set_value_by_id
+ lv_chart_set_value_by_id2
+ lv_chart_set_x_start_point
- lv_checkbox_get_text
+ lv_dropdown_add_option
+ lv_dropdown_get_dir
- lv_dropdown_get_list
- lv_dropdown_get_options
+ lv_dropdown_get_selected_str
- lv_dropdown_get_symbol
- lv_dropdown_get_text
+ lv_dropdown_set_dir
- lv_dropdown_set_symbol
- lv_imgbtn_get_src_left
- lv_imgbtn_get_src_middle
- lv_imgbtn_get_src_right
- lv_imgbtn_set_src
+ lv_imgbtn_set_state
+ lv_img_get_offset_x
+ lv_img_get_offset_y
+ lv_img_get_pivot
+ lv_img_get_size_mode
- lv_img_get_src
+ lv_img_set_angle
+ lv_img_set_offset_x
+ lv_img_set_offset_y
+ lv_img_set_pivot
+ lv_img_set_size_mode
- lv_img_set_src
+ lv_keyboard_get_mode
- lv_keyboard_get_textarea
- lv_keyboard_set_map
+ lv_keyboard_set_mode
+ lv_keyboard_set_textarea
+ lv_label_cut_text
+ lv_label_get_letter_on
+ lv_label_get_letter_pos
+ lv_label_get_long_mode
- lv_label_get_text
+ lv_label_ins_text
+ lv_label_is_char_under_pos
+ lv_label_set_long_mode
+ lv_label_set_text_sel_end
+ lv_label_set_text_sel_start
+ lv_led_set_color
+ lv_line_set_points
- lv_list_add_btn
- lv_list_add_text
- lv_list_get_btn_text
+ lv_menu_back_btn_is_root
- lv_menu_get_cur_main_page
- lv_menu_get_cur_sidebar_page
- lv_menu_get_main_header
- lv_menu_get_main_header_back_btn
- lv_menu_get_sidebar_header
- lv_menu_get_sidebar_header_back_btn
+ lv_menu_set_load_page_event
+ lv_menu_set_mode_header
+ lv_menu_set_mode_root_back_btn
+ lv_menu_set_page
+ lv_menu_set_sidebar_page
- lv_meter_add_arc
- lv_meter_add_needle_img
- lv_meter_add_needle_line
- lv_meter_add_scale
- lv_meter_add_scale_lines
+ lv_meter_set_indicator_end_value
+ lv_meter_set_indicator_start_value
+ lv_meter_set_indicator_value
+ lv_meter_set_scale_major_ticks
+ lv_meter_set_scale_range
+ lv_meter_set_scale_ticks
- lv_obj_add_event_cb
+ lv_obj_add_flag
+ lv_obj_add_state
+ lv_obj_add_style
+ lv_obj_align
+ lv_obj_align_to
+ lv_obj_area_is_visible
+ lv_obj_calculate_ext_draw_size
+ lv_obj_calculate_style_text_align
+ lv_obj_check_type
+ lv_obj_clear_flag
+ lv_obj_clear_state
+ lv_obj_del_delayed
+ lv_obj_fade_in
+ lv_obj_fade_out
- lv_obj_get_child
- lv_obj_get_class
+ lv_obj_get_click_area
+ lv_obj_get_content_coords
+ lv_obj_get_content_height
+ lv_obj_get_content_width
+ lv_obj_get_coords
- lv_obj_get_disp
- lv_obj_get_event_user_data
- lv_obj_get_group
+ lv_obj_get_height
+ lv_obj_get_local_style_prop
- lv_obj_get_parent
- lv_obj_get_screen
+ lv_obj_get_scrollbar_area
+ lv_obj_get_scrollbar_mode
+ lv_obj_get_scroll_bottom
+ lv_obj_get_scroll_dir
+ lv_obj_get_scroll_end
+ lv_obj_get_scroll_left
+ lv_obj_get_scroll_right
+ lv_obj_get_scroll_snap_x
+ lv_obj_get_scroll_snap_y
+ lv_obj_get_scroll_top
+ lv_obj_get_scroll_x
+ lv_obj_get_scroll_y
+ lv_obj_get_self_height
+ lv_obj_get_self_width
+ lv_obj_get_state
+ lv_obj_get_style_prop
+ lv_obj_get_transformed_area
+ lv_obj_get_width
+ lv_obj_get_x
+ lv_obj_get_x2
+ lv_obj_get_x_aligned
+ lv_obj_get_y
+ lv_obj_get_y2
+ lv_obj_get_y_aligned
+ lv_obj_has_class
+ lv_obj_has_flag
+ lv_obj_has_flag_any
+ lv_obj_has_state
+ lv_obj_hit_test
+ lv_obj_init_draw_arc_dsc
+ lv_obj_init_draw_img_dsc
+ lv_obj_init_draw_label_dsc
+ lv_obj_init_draw_line_dsc
+ lv_obj_init_draw_rect_dsc
+ lv_obj_invalidate_area
+ lv_obj_move_children_by
+ lv_obj_move_to
+ lv_obj_readjust_scroll
+ lv_obj_refresh_style
+ lv_obj_remove_event_cb
- lv_obj_remove_event_cb_with_user_data
+ lv_obj_remove_event_dsc
+ lv_obj_remove_local_style_prop
+ lv_obj_remove_style
+ lv_obj_scroll_by
+ lv_obj_scroll_by_bounded
+ lv_obj_scroll_to
+ lv_obj_scroll_to_view
+ lv_obj_scroll_to_view_recursive
+ lv_obj_scroll_to_x
+ lv_obj_scroll_to_y
+ lv_obj_set_align
+ lv_obj_set_content_height
+ lv_obj_set_content_width
+ lv_obj_set_ext_click_area
+ lv_obj_set_flex_align
+ lv_obj_set_flex_flow
+ lv_obj_set_grid_align
+ lv_obj_set_grid_cell
+ lv_obj_set_grid_dsc_array
+ lv_obj_set_height
+ lv_obj_set_layout
+ lv_obj_set_local_style_prop
+ lv_obj_set_local_style_prop_meta
+ lv_obj_set_parent
+ lv_obj_set_pos
+ lv_obj_set_scrollbar_mode
+ lv_obj_set_scroll_dir
+ lv_obj_set_scroll_snap_x
+ lv_obj_set_scroll_snap_y
+ lv_obj_set_size
+ lv_obj_set_style_align
+ lv_obj_set_style_anim
+ lv_obj_set_style_anim_speed
+ lv_obj_set_style_anim_time
+ lv_obj_set_style_arc_color
- lv_obj_set_style_arc_img_src
+ lv_obj_set_style_arc_opa
+ lv_obj_set_style_arc_rounded
+ lv_obj_set_style_arc_width
+ lv_obj_set_style_base_dir
+ lv_obj_set_style_bg_color
+ lv_obj_set_style_bg_dither_mode
+ lv_obj_set_style_bg_grad
+ lv_obj_set_style_bg_grad_color
+ lv_obj_set_style_bg_grad_dir
+ lv_obj_set_style_bg_grad_stop
+ lv_obj_set_style_bg_img_opa
+ lv_obj_set_style_bg_img_recolor
+ lv_obj_set_style_bg_img_recolor_opa
- lv_obj_set_style_bg_img_src
+ lv_obj_set_style_bg_img_tiled
+ lv_obj_set_style_bg_main_stop
+ lv_obj_set_style_bg_opa
+ lv_obj_set_style_blend_mode
+ lv_obj_set_style_border_color
+ lv_obj_set_style_border_opa
+ lv_obj_set_style_border_post
+ lv_obj_set_style_border_side
+ lv_obj_set_style_border_width
+ lv_obj_set_style_clip_corner
+ lv_obj_set_style_color_filter_dsc
+ lv_obj_set_style_color_filter_opa
+ lv_obj_set_style_flex_cross_place
+ lv_obj_set_style_flex_flow
+ lv_obj_set_style_flex_grow
+ lv_obj_set_style_flex_main_place
+ lv_obj_set_style_flex_track_place
+ lv_obj_set_style_grid_cell_column_pos
+ lv_obj_set_style_grid_cell_column_span
+ lv_obj_set_style_grid_cell_row_pos
+ lv_obj_set_style_grid_cell_row_span
+ lv_obj_set_style_grid_cell_x_align
+ lv_obj_set_style_grid_cell_y_align
+ lv_obj_set_style_grid_column_align
+ lv_obj_set_style_grid_column_dsc_array
+ lv_obj_set_style_grid_row_align
+ lv_obj_set_style_grid_row_dsc_array
+ lv_obj_set_style_height
+ lv_obj_set_style_img_opa
+ lv_obj_set_style_img_recolor
+ lv_obj_set_style_img_recolor_opa
+ lv_obj_set_style_layout
+ lv_obj_set_style_line_color
+ lv_obj_set_style_line_dash_gap
+ lv_obj_set_style_line_dash_width
+ lv_obj_set_style_line_opa
+ lv_obj_set_style_line_rounded
+ lv_obj_set_style_line_width
+ lv_obj_set_style_max_height
+ lv_obj_set_style_max_width
+ lv_obj_set_style_min_height
+ lv_obj_set_style_min_width
+ lv_obj_set_style_opa
+ lv_obj_set_style_outline_color
+ lv_obj_set_style_outline_opa
+ lv_obj_set_style_outline_pad
+ lv_obj_set_style_outline_width
+ lv_obj_set_style_pad_bottom
+ lv_obj_set_style_pad_column
+ lv_obj_set_style_pad_left
+ lv_obj_set_style_pad_right
+ lv_obj_set_style_pad_row
+ lv_obj_set_style_pad_top
+ lv_obj_set_style_radius
+ lv_obj_set_style_shadow_color
+ lv_obj_set_style_shadow_ofs_x
+ lv_obj_set_style_shadow_ofs_y
+ lv_obj_set_style_shadow_opa
+ lv_obj_set_style_shadow_spread
+ lv_obj_set_style_shadow_width
+ lv_obj_set_style_text_align
+ lv_obj_set_style_text_color
+ lv_obj_set_style_text_decor
+ lv_obj_set_style_text_font
+ lv_obj_set_style_text_letter_space
+ lv_obj_set_style_text_line_space
+ lv_obj_set_style_text_opa
+ lv_obj_set_style_transform_angle
+ lv_obj_set_style_transform_height
+ lv_obj_set_style_transform_pivot_x
+ lv_obj_set_style_transform_pivot_y
+ lv_obj_set_style_transform_width
+ lv_obj_set_style_transform_zoom
+ lv_obj_set_style_transition
+ lv_obj_set_style_translate_x
+ lv_obj_set_style_translate_y
+ lv_obj_set_style_width
+ lv_obj_set_style_x
+ lv_obj_set_style_y
+ lv_obj_set_tile
+ lv_obj_set_tile_id
+ lv_obj_set_width
+ lv_obj_set_x
+ lv_obj_set_y
+ lv_obj_swap
+ lv_obj_transform_point
- lv_obj_tree_walk
+ lv_obj_update_snap
- lv_roller_get_options
+ lv_roller_get_selected_str
+ lv_roller_set_options
+ lv_roller_set_selected
+ lv_spangroup_del_span
+ lv_spangroup_get_align
- lv_spangroup_get_child
+ lv_spangroup_get_expand_height
+ lv_spangroup_get_expand_width
+ lv_spangroup_get_indent
+ lv_spangroup_get_max_line_h
+ lv_spangroup_get_mode
+ lv_spangroup_get_overflow
- lv_spangroup_new_span
+ lv_spangroup_set_align
+ lv_spangroup_set_indent
+ lv_spangroup_set_mode
+ lv_spangroup_set_overflow
+ lv_spinbox_set_digit_step_direction
+ lv_spinbox_set_step
+ lv_table_add_cell_ctrl
+ lv_table_clear_cell_ctrl
- lv_table_get_cell_value
+ lv_table_get_col_width
+ lv_table_get_selected_cell
+ lv_table_has_cell_ctrl
+ lv_table_set_col_width
+ lv_textarea_add_char
- lv_textarea_get_accepted_chars
- lv_textarea_get_label
- lv_textarea_get_password_bullet
- lv_textarea_get_placeholder_text
- lv_textarea_get_text
+ lv_textarea_set_align
+ lv_textarea_set_max_length
- lv_tileview_add_tile
- lv_tileview_get_tile_act
```

</details>

This breaks the API as what previously took a Rust enum, now takes an i32.
```diff
-        bar.set_value(i, AnimationState::ON);
+        bar.set_value(i, AnimationState::ON.into());
```
```diff
-        button.set_align(Align::LeftMid, 30, 0);
+        button.align(Align::LeftMid.into(), 30, 0);
```
```diff
-        screen.add_style(Part::Main, &mut screen_style);
+        screen.add_style(screen_style.into_raw(), Part::Main.into());
```
Arrays, void pointers and returned pointers still do not work (those functions are skipped)