### PR TITLE
Fix Windows builds

### DIFF
--- a/lvgl/src/input_device/encoder.rs
+++ b/lvgl/src/input_device/encoder.rs
@@ -119,21 +119,23 @@ unsafe extern "C" fn read_input<F>(
             BufferStatus::Once(b) => {
                 (*data).state = match b {
                     InputState::Pressed(Data::Encoder(d)) => {
+                        // needs i32 -> u32 conversion on windows
                         (*data).key = match d {
                             EncoderInputData::Press => lvgl_sys::LV_KEY_ENTER,
                             EncoderInputData::LongPress => lvgl_sys::LV_KEY_ENTER,
                             EncoderInputData::TurnLeft => lvgl_sys::LV_KEY_LEFT,
                             EncoderInputData::TurnRight => lvgl_sys::LV_KEY_RIGHT,
-                        };
+                        } as u32;
                         lvgl_sys::lv_indev_state_t_LV_INDEV_STATE_PRESSED
                     }
                     InputState::Released(Data::Encoder(d)) => {
+                        // needs i32 -> u32 conversion on windows
                         (*data).key = match d {
                             EncoderInputData::Press => lvgl_sys::LV_KEY_ENTER,
                             EncoderInputData::LongPress => lvgl_sys::LV_KEY_ENTER,
                             EncoderInputData::TurnLeft => lvgl_sys::LV_KEY_LEFT,
                             EncoderInputData::TurnRight => lvgl_sys::LV_KEY_RIGHT,
-                        };
+                        } as u32;
                         lvgl_sys::lv_indev_state_t_LV_INDEV_STATE_RELEASED
                     }
                     _ => panic!("Non-encoder data returned from encoder device!"),
@@ -143,21 +145,23 @@ unsafe extern "C" fn read_input<F>(
             BufferStatus::Buffered(b) => {
                 (*data).state = match b {
                     InputState::Pressed(Data::Encoder(d)) => {
+                        // needs i32 -> u32 conversion on windows
                         (*data).key = match d {
                             EncoderInputData::Press => lvgl_sys::LV_KEY_ENTER,
                             EncoderInputData::LongPress => lvgl_sys::LV_KEY_ENTER,
                             EncoderInputData::TurnLeft => lvgl_sys::LV_KEY_LEFT,
                             EncoderInputData::TurnRight => lvgl_sys::LV_KEY_RIGHT,
-                        };
+                        } as u32;
                         lvgl_sys::lv_indev_state_t_LV_INDEV_STATE_PRESSED
                     }
                     InputState::Released(Data::Encoder(d)) => {
+                        // needs i32 -> u32 conversion on windows
                         (*data).key = match d {
                             EncoderInputData::Press => lvgl_sys::LV_KEY_ENTER,
                             EncoderInputData::LongPress => lvgl_sys::LV_KEY_ENTER,
                             EncoderInputData::TurnLeft => lvgl_sys::LV_KEY_LEFT,
                             EncoderInputData::TurnRight => lvgl_sys::LV_KEY_RIGHT,
-                        };
+                        } as u32;
                         lvgl_sys::lv_indev_state_t_LV_INDEV_STATE_RELEASED
                     }
                     _ => panic!("Non-encoder data returned from encoder device!"),

--- a/lvgl/src/lv_core/obj.rs
+++ b/lvgl/src/lv_core/obj.rs
@@ -278,7 +278,8 @@ impl Default for Part {
 
 impl From<Part> for lvgl_sys::lv_part_t {
     fn from(self_: Part) -> lvgl_sys::lv_part_t {
-        match self_ {
+        // needs i32 -> u32 conversion on windows
+        (match self_ {
             Part::Main => lvgl_sys::LV_PART_MAIN,
             Part::Scrollbar => lvgl_sys::LV_PART_SCROLLBAR,
             Part::Indicator => lvgl_sys::LV_PART_INDICATOR,
@@ -289,6 +290,6 @@ impl From<Part> for lvgl_sys::lv_part_t {
             Part::Cursor => lvgl_sys::LV_PART_CURSOR,
             Part::CustomFirst => lvgl_sys::LV_PART_CUSTOM_FIRST,
             Part::Any => lvgl_sys::LV_PART_ANY,
-        }
+        }) as lvgl_sys::lv_part_t
     }
 }

--- a/lvgl/src/lv_core/style.rs
+++ b/lvgl/src/lv_core/style.rs
@@ -22,6 +22,11 @@ use core::mem::{self, MaybeUninit};
 use cty::c_uint;
 use paste::paste;
 
+#[cfg(unix)]
+type CEnum = u32;
+#[cfg(windows)]
+type CEnum = i32;
+
 pub enum Themes {
     Pretty,
 }
@@ -56,7 +61,7 @@ impl Default for Style {
 bitflags! {
     /// Represents possible opacities for use on `Style` objects.
     #[derive(Debug, Clone, Copy)]
-    pub struct Opacity: u32 {
+    pub struct Opacity: CEnum {
         const OPA_TRANSP = lvgl_sys::LV_OPA_TRANSP;
         const OPA_0 = lvgl_sys::LV_OPA_0;
         const OPA_10 = lvgl_sys::LV_OPA_10;
@@ -73,14 +78,14 @@ bitflags! {
     }
 }
 
-impl From<Opacity> for u8 {
-    fn from(value: Opacity) -> u8 {
-        value.bits() as u8
+impl From<Opacity> for lvgl_sys::lv_opa_t {
+    fn from(value: Opacity) -> lvgl_sys::lv_opa_t {
+        value.bits() as lvgl_sys::lv_opa_t
     }
 }
 
 bitflags! {
-    pub struct GridAlign: c_uint {
+    pub struct GridAlign: lvgl_sys::lv_grid_align_t {
         const START = lvgl_sys::lv_grid_align_t_LV_GRID_ALIGN_START;
         const CENTER = lvgl_sys::lv_grid_align_t_LV_GRID_ALIGN_CENTER;
         const END = lvgl_sys::lv_grid_align_t_LV_GRID_ALIGN_END;
@@ -91,9 +96,9 @@ bitflags! {
     }
 }
 
-impl From<GridAlign> for c_uint {
+impl From<GridAlign> for lvgl_sys::lv_grid_align_t {
     fn from(value: GridAlign) -> Self {
-        value.bits() as c_uint
+        value.bits() as lvgl_sys::lv_grid_align_t
     }
 }
 
@@ -104,7 +109,7 @@ impl From<GridAlign> for i16 {
 }
 
 bitflags! {
-    pub struct FlexAlign: c_uint {
+    pub struct FlexAlign: lvgl_sys::lv_flex_align_t {
         const START = lvgl_sys::lv_flex_align_t_LV_FLEX_ALIGN_START;
         const CENTER = lvgl_sys::lv_flex_align_t_LV_FLEX_ALIGN_CENTER;
         const END = lvgl_sys::lv_flex_align_t_LV_FLEX_ALIGN_END;
@@ -114,14 +119,14 @@ bitflags! {
     }
 }
 
-impl From<FlexAlign> for c_uint {
+impl From<FlexAlign> for lvgl_sys::lv_flex_align_t {
     fn from(value: FlexAlign) -> Self {
-        value.bits() as c_uint
+        value.bits() as lvgl_sys::lv_flex_align_t
     }
 }
 
 bitflags! {
-    pub struct FlexFlow: c_uint {
+    pub struct FlexFlow: lvgl_sys::lv_flex_flow_t {
         const COLUMN = lvgl_sys::lv_flex_flow_t_LV_FLEX_FLOW_COLUMN;
         const COLUMN_REVERSE = lvgl_sys::lv_flex_flow_t_LV_FLEX_FLOW_COLUMN_REVERSE;
         const COLUMN_WRAP = lvgl_sys::lv_flex_flow_t_LV_FLEX_FLOW_COLUMN_WRAP;
@@ -133,9 +138,9 @@ bitflags! {
     }
 }
 
-impl From<FlexFlow> for c_uint {
+impl From<FlexFlow> for lvgl_sys::lv_flex_flow_t {
     fn from(value: FlexFlow) -> Self {
-        value.bits() as c_uint
+        value.bits() as lvgl_sys::lv_flex_flow_t
     }
 }
 
@@ -245,7 +250,7 @@ impl From<lvgl_sys::lv_style_value_t> for StyleValues {
 bitflags! {
     /// Various constants relevant for `Style` parameters
     #[derive(PartialEq, Eq)]
-    pub struct StyleProp: u32 {
+    pub struct StyleProp:  lvgl_sys::lv_style_prop_t {
         //const PROP_INV = lvgl_sys::lv_style_prop_t_LV_STYLE_PROP_INV;
 
         /*Group 0*/
@@ -459,7 +464,7 @@ impl Style {
             lvgl_sys::lv_style_get_prop(self.raw.clone().into_raw() as *const _, prop.bits(), ptr)
         };
         let raw_ret = unsafe { raw_ret.assume_init() };
-        if <u8 as Into<u32>>::into(result) == lvgl_sys::LV_RES_OK {
+        if <u8 as Into<lvgl_sys::lv_style_prop_t>>::into(result) == lvgl_sys::LV_RES_OK {
             unsafe {
                 ret = match ret {
                     StyleValues::Num(_) => StyleValues::Num(raw_ret.num),

--- a/lvgl/src/misc/anim.rs
+++ b/lvgl/src/misc/anim.rs
@@ -115,7 +115,7 @@ where
         // yes, we have to do it this way. Casting `obj` directly to `&mut Obj` segfaults
         let obj = (*(obj as *mut T)).raw();
         if !anim.as_ref().user_data.is_null() {
-            let callback = &mut *(obj.as_ref().user_data as *mut F);
+            let callback = &mut *(anim.as_ref().user_data as *mut F);
             let mut obj_nondrop = Obj::from_raw(obj).unwrap();
             callback(&mut obj_nondrop, val);
             mem::forget(obj_nondrop)

--- a/lvgl/src/support.rs
+++ b/lvgl/src/support.rs
@@ -200,24 +200,40 @@ impl<S> TryFrom<lvgl_sys::lv_event_code_t> for Event<S> {
     type Error = ();
 
     fn try_from(value: lvgl_sys::lv_event_code_t) -> Result<Self, Self::Error> {
-        const LV_EVENT_PRESSED: u32 = lvgl_sys::lv_event_code_t_LV_EVENT_PRESSED;
-        const LV_EVENT_PRESSING: u32 = lvgl_sys::lv_event_code_t_LV_EVENT_PRESSING;
-        const LV_EVENT_PRESS_LOST: u32 = lvgl_sys::lv_event_code_t_LV_EVENT_PRESS_LOST;
-        const LV_EVENT_SHORT_CLICKED: u32 = lvgl_sys::lv_event_code_t_LV_EVENT_SHORT_CLICKED;
-        const LV_EVENT_CLICKED: u32 = lvgl_sys::lv_event_code_t_LV_EVENT_CLICKED;
-        const LV_EVENT_LONG_PRESSED: u32 = lvgl_sys::lv_event_code_t_LV_EVENT_LONG_PRESSED;
-        const LV_EVENT_LONG_PRESSED_REPEAT: u32 =
+        const LV_EVENT_PRESSED: lvgl_sys::lv_event_code_t =
+            lvgl_sys::lv_event_code_t_LV_EVENT_PRESSED;
+        const LV_EVENT_PRESSING: lvgl_sys::lv_event_code_t =
+            lvgl_sys::lv_event_code_t_LV_EVENT_PRESSING;
+        const LV_EVENT_PRESS_LOST: lvgl_sys::lv_event_code_t =
+            lvgl_sys::lv_event_code_t_LV_EVENT_PRESS_LOST;
+        const LV_EVENT_SHORT_CLICKED: lvgl_sys::lv_event_code_t =
+            lvgl_sys::lv_event_code_t_LV_EVENT_SHORT_CLICKED;
+        const LV_EVENT_CLICKED: lvgl_sys::lv_event_code_t =
+            lvgl_sys::lv_event_code_t_LV_EVENT_CLICKED;
+        const LV_EVENT_LONG_PRESSED: lvgl_sys::lv_event_code_t =
+            lvgl_sys::lv_event_code_t_LV_EVENT_LONG_PRESSED;
+        const LV_EVENT_LONG_PRESSED_REPEAT: lvgl_sys::lv_event_code_t =
             lvgl_sys::lv_event_code_t_LV_EVENT_LONG_PRESSED_REPEAT;
-        const LV_EVENT_RELEASED: u32 = lvgl_sys::lv_event_code_t_LV_EVENT_RELEASED;
-        const LV_EVENT_VALUE_CHANGED: u32 = lvgl_sys::lv_event_code_t_LV_EVENT_VALUE_CHANGED;
-        const LV_EVENT_DRAW_MAIN: u32 = lvgl_sys::lv_event_code_t_LV_EVENT_DRAW_MAIN;
-        const LV_EVENT_DRAW_MAIN_BEGIN: u32 = lvgl_sys::lv_event_code_t_LV_EVENT_DRAW_MAIN_BEGIN;
-        const LV_EVENT_DRAW_MAIN_END: u32 = lvgl_sys::lv_event_code_t_LV_EVENT_DRAW_MAIN_END;
-        const LV_EVENT_DRAW_PART_BEGIN: u32 = lvgl_sys::lv_event_code_t_LV_EVENT_DRAW_PART_BEGIN;
-        const LV_EVENT_DRAW_PART_END: u32 = lvgl_sys::lv_event_code_t_LV_EVENT_DRAW_PART_END;
-        const LV_EVENT_DRAW_POST: u32 = lvgl_sys::lv_event_code_t_LV_EVENT_DRAW_POST;
-        const LV_EVENT_DRAW_POST_BEGIN: u32 = lvgl_sys::lv_event_code_t_LV_EVENT_DRAW_POST_BEGIN;
-        const LV_EVENT_DRAW_POST_END: u32 = lvgl_sys::lv_event_code_t_LV_EVENT_DRAW_POST_END;
+        const LV_EVENT_RELEASED: lvgl_sys::lv_event_code_t =
+            lvgl_sys::lv_event_code_t_LV_EVENT_RELEASED;
+        const LV_EVENT_VALUE_CHANGED: lvgl_sys::lv_event_code_t =
+            lvgl_sys::lv_event_code_t_LV_EVENT_VALUE_CHANGED;
+        const LV_EVENT_DRAW_MAIN: lvgl_sys::lv_event_code_t =
+            lvgl_sys::lv_event_code_t_LV_EVENT_DRAW_MAIN;
+        const LV_EVENT_DRAW_MAIN_BEGIN: lvgl_sys::lv_event_code_t =
+            lvgl_sys::lv_event_code_t_LV_EVENT_DRAW_MAIN_BEGIN;
+        const LV_EVENT_DRAW_MAIN_END: lvgl_sys::lv_event_code_t =
+            lvgl_sys::lv_event_code_t_LV_EVENT_DRAW_MAIN_END;
+        const LV_EVENT_DRAW_PART_BEGIN: lvgl_sys::lv_event_code_t =
+            lvgl_sys::lv_event_code_t_LV_EVENT_DRAW_PART_BEGIN;
+        const LV_EVENT_DRAW_PART_END: lvgl_sys::lv_event_code_t =
+            lvgl_sys::lv_event_code_t_LV_EVENT_DRAW_PART_END;
+        const LV_EVENT_DRAW_POST: lvgl_sys::lv_event_code_t =
+            lvgl_sys::lv_event_code_t_LV_EVENT_DRAW_POST;
+        const LV_EVENT_DRAW_POST_BEGIN: lvgl_sys::lv_event_code_t =
+            lvgl_sys::lv_event_code_t_LV_EVENT_DRAW_POST_BEGIN;
+        const LV_EVENT_DRAW_POST_END: lvgl_sys::lv_event_code_t =
+            lvgl_sys::lv_event_code_t_LV_EVENT_DRAW_POST_END;
 
         match value {
             LV_EVENT_PRESSED => Ok(Event::Pressed),

--- a/lvgl/src/support.rs
+++ b/lvgl/src/support.rs
@@ -8,6 +8,11 @@ use core::ptr::NonNull;
 #[cfg(feature = "embedded_graphics")]
 use embedded_graphics::pixelcolor::{Rgb565, Rgb888};
 
+#[cfg(unix)]
+type CEnum = u32;
+#[cfg(windows)]
+type CEnum = i32;
+
 pub type LvResult<T> = Result<T, LvError>;
 
 /// Generic LVGL error. All other errors can be coerced into it.
@@ -400,6 +405,7 @@ impl From<AnimationState> for lvgl_sys::lv_anim_enable_t {
     }
 }
 
+#[cfg(unix)]
 #[repr(u32)]
 pub enum LabelLongMode {
     Clip = lvgl_sys::LV_LABEL_LONG_CLIP,
@@ -409,9 +415,19 @@ pub enum LabelLongMode {
     Wrap = lvgl_sys::LV_LABEL_LONG_WRAP,
 }
 
-impl From<LabelLongMode> for u8 {
+#[cfg(windows)]
+#[repr(i32)]
+pub enum LabelLongMode {
+    Clip = lvgl_sys::LV_LABEL_LONG_CLIP,
+    Dot = lvgl_sys::LV_LABEL_LONG_DOT,
+    Scroll = lvgl_sys::LV_LABEL_LONG_SCROLL,
+    ScrollCircular = lvgl_sys::LV_LABEL_LONG_SCROLL_CIRCULAR,
+    Wrap = lvgl_sys::LV_LABEL_LONG_WRAP,
+}
+
+impl From<LabelLongMode> for lvgl_sys::lv_label_long_mode_t {
     fn from(value: LabelLongMode) -> Self {
-        unsafe { (value as u32).try_into().unwrap_unchecked() }
+        unsafe { (value as CEnum).try_into().unwrap_unchecked() }
     }
 }
 

--- a/lvgl/src/support.rs
+++ b/lvgl/src/support.rs
@@ -8,11 +8,6 @@ use core::ptr::NonNull;
 #[cfg(feature = "embedded_graphics")]
 use embedded_graphics::pixelcolor::{Rgb565, Rgb888};
 
-#[cfg(unix)]
-type CEnum = u32;
-#[cfg(windows)]
-type CEnum = i32;
-
 pub type LvResult<T> = Result<T, LvError>;
 
 /// Generic LVGL error. All other errors can be coerced into it.
@@ -427,7 +422,7 @@ pub enum LabelLongMode {
 
 impl From<LabelLongMode> for lvgl_sys::lv_label_long_mode_t {
     fn from(value: LabelLongMode) -> Self {
-        unsafe { (value as CEnum).try_into().unwrap_unchecked() }
+        unsafe { value.try_into().unwrap_unchecked() }
     }
 }
 


### PR DESCRIPTION
Fixes #196 

In many places values are hard-coded as u32, however on Windows bindgen generates them as i32. This PR replaces them with either LVGL types or type casts.


See https://github.com/rust-lang/rust-bindgen/issues/1244, https://github.com/rust-lang/rust-bindgen/issues/1361